### PR TITLE
feat: Implement Core Knowledge Ecosystem Platform

### DIFF
--- a/chs-frontend/src/App.js
+++ b/chs-frontend/src/App.js
@@ -5,6 +5,10 @@ import RegisterPage from './pages/RegisterPage';
 import DashboardPage from './pages/DashboardPage';
 import WorkbenchPage from './pages/WorkbenchPage';
 import SituationalAwarenessPage from './pages/SituationalAwarenessPage';
+import CourseLibraryPage from './pages/CourseLibraryPage';
+import CodeAssetLibraryPage from './pages/CodeAssetLibraryPage';
+import CourseDetailPage from './pages/CourseDetailPage';
+import KnowledgeGraphPage from './pages/KnowledgeGraphPage'; // Import graph page
 import MainLayout from './layouts/MainLayout';
 import authService from './services/authService';
 
@@ -25,6 +29,10 @@ const App = () => {
                   <Route path="/" element={<SituationalAwarenessPage />} />
                   <Route path="/dashboard" element={<DashboardPage />} />
                   <Route path="/workbench" element={<WorkbenchPage />} />
+                  <Route path="/courses" element={<CourseLibraryPage />} />
+                  <Route path="/courses/:id" element={<CourseDetailPage />} />
+                  <Route path="/assets" element={<CodeAssetLibraryPage />} />
+                  <Route path="/knowledge-graph" element={<KnowledgeGraphPage />} />
                   {/* Other protected routes can go here */}
                   <Route path="*" element={<Navigate to="/" />} />
                 </Routes>

--- a/chs-frontend/src/layouts/MainLayout.js
+++ b/chs-frontend/src/layouts/MainLayout.js
@@ -7,6 +7,9 @@ import {
   ProjectOutlined,
   UserOutlined,
   DownOutlined,
+  ReadOutlined, // Icon for Courses
+  CodeOutlined, // Icon for Code Assets
+  ApartmentOutlined, // Icon for Knowledge Graph
 } from '@ant-design/icons';
 import { Link, useNavigate } from 'react-router-dom';
 import useAuthStore from '../store/useAuthStore';
@@ -44,6 +47,15 @@ const MainLayout = ({ children }) => {
           </Menu.Item>
           <Menu.Item key="2" icon={<ProjectOutlined />}>
             <Link to="/workbench">Modeling Workbench</Link>
+          </Menu.Item>
+          <Menu.Item key="3" icon={<ApartmentOutlined />}>
+            <Link to="/knowledge-graph">知识图谱</Link>
+          </Menu.Item>
+          <Menu.Item key="4" icon={<ReadOutlined />}>
+            <Link to="/courses">精品课程</Link>
+          </Menu.Item>
+          <Menu.Item key="5" icon={<CodeOutlined />}>
+            <Link to="/assets">代码库</Link>
           </Menu.Item>
         </Menu>
       </Sider>

--- a/chs-frontend/src/pages/CodeAssetLibraryPage.js
+++ b/chs-frontend/src/pages/CodeAssetLibraryPage.js
@@ -1,0 +1,73 @@
+import React, { useState, useEffect } from 'react';
+import { Layout, Typography, Card, Row, Col, Tag, Spin, Alert } from 'antd';
+import MainLayout from '../layouts/MainLayout';
+import codeAssetService from '../services/codeAssetService';
+
+const { Title, Paragraph } = Typography;
+const { Content } = Layout;
+
+const CodeAssetLibraryPage = () => {
+  const [snippets, setSnippets] = useState([]);
+  const [notebooks, setNotebooks] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const snippetsResponse = await codeAssetService.getAllCodeSnippets();
+        const notebooksResponse = await codeAssetService.getAllNotebooks();
+        setSnippets(snippetsResponse.data);
+        setNotebooks(notebooksResponse.data);
+        setError(null);
+      } catch (err) {
+        console.error("Failed to fetch code assets:", err);
+        setError("无法加载代码资产，请稍后再试。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  return (
+    <MainLayout>
+      <Content style={{ padding: '50px' }}>
+        <Title level={2}>代码片段与Notebook库</Title>
+        <Paragraph>这里提供了即插即用、经过验证的代码资产，加速您的研究与开发过程。</Paragraph>
+
+        {loading && <Spin tip="加载中..." size="large" />}
+        {error && <Alert message="错误" description={error} type="error" showIcon />}
+
+        {!loading && !error && (
+          <>
+            <Title level={3} style={{ marginTop: '40px' }}>代码片段</Title>
+            <Row gutter={[16, 16]}>
+              {snippets.map(snippet => (
+                <Col span={8} key={snippet.id}>
+                  <Card title={snippet.title} extra={<Tag>{snippet.language}</Tag>} hoverable>
+                    {snippet.description}
+                  </Card>
+                </Col>
+              ))}
+            </Row>
+
+            <Title level={3} style={{ marginTop: '40px' }}>交互式Notebook</Title>
+            <Row gutter={[16, 16]}>
+              {notebooks.map(notebook => (
+                <Col span={8} key={notebook.id}>
+                  <Card title={notebook.title} hoverable>
+                    {notebook.description}
+                  </Card>
+                </Col>
+              ))}
+            </Row>
+          </>
+        )}
+      </Content>
+    </MainLayout>
+  );
+};
+
+export default CodeAssetLibraryPage;

--- a/chs-frontend/src/pages/CourseDetailPage.js
+++ b/chs-frontend/src/pages/CourseDetailPage.js
@@ -1,0 +1,106 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { Layout, Typography, Spin, Alert, List, Card, Breadcrumb } from 'antd';
+import MainLayout from '../layouts/MainLayout';
+import courseService from '../services/courseService';
+import useKnowledgeGraphStore from '../store/useKnowledgeGraphStore';
+
+const { Title, Paragraph } = Typography;
+const { Content } = Layout;
+
+const CourseDetailPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const { setHighlightedNodeId } = useKnowledgeGraphStore();
+  const [course, setCourse] = useState(null);
+  const [lessons, setLessons] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const contentRef = useRef(null);
+
+  useEffect(() => {
+    const fetchCourseData = async () => {
+      try {
+        setLoading(true);
+        const courseResponse = await courseService.getCourseById(id);
+        // For demo, let's assume lesson content has special links
+        // e.g., <a href="#" data-knowledge-point="4">卡尔曼滤波</a>
+        const lessonsResponse = await courseService.getLessonsByCourseId(id);
+        setCourse(courseResponse.data);
+        setLessons(lessonsResponse.data);
+        setError(null);
+      } catch (err) {
+        console.error("Failed to fetch course details:", err);
+        setError("无法加载课程详情，请稍后再试。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCourseData();
+  }, [id]);
+
+  useEffect(() => {
+    const handleKnowledgeLinkClick = (e) => {
+      const target = e.target.closest('a[data-knowledge-point]');
+      if (!target) return;
+
+      e.preventDefault();
+      const nodeId = target.getAttribute('data-knowledge-point');
+      console.log('Highlighting node:', nodeId);
+      setHighlightedNodeId(nodeId);
+      navigate('/knowledge-graph');
+    };
+
+    const contentElement = contentRef.current;
+    if (contentElement) {
+      contentElement.addEventListener('click', handleKnowledgeLinkClick);
+    }
+
+    return () => {
+      if (contentElement) {
+        contentElement.removeEventListener('click', handleKnowledgeLinkClick);
+      }
+    };
+  }, [lessons, navigate, setHighlightedNodeId]);
+
+  if (loading) {
+    return <MainLayout><Spin tip="加载中..." size="large" style={{ display: 'block', marginTop: '50px' }} /></MainLayout>;
+  }
+
+  if (error) {
+    return <MainLayout><Alert message="错误" description={error} type="error" showIcon /></MainLayout>;
+  }
+
+  return (
+    <MainLayout>
+      <Content style={{ padding: '50px' }}>
+        <Breadcrumb style={{ marginBottom: '16px' }}>
+          <Breadcrumb.Item><Link to="/courses">精品课程库</Link></Breadcrumb.Item>
+          <Breadcrumb.Item>{course?.title}</Breadcrumb.Item>
+        </Breadcrumb>
+
+        <Card>
+          <Title level={2}>{course?.title}</Title>
+          <Paragraph>{course?.description}</Paragraph>
+        </Card>
+
+        <Title level={3} style={{ marginTop: '40px' }}>课程章节</Title>
+        <div ref={contentRef}>
+          <List
+            grid={{ gutter: 16, column: 1 }}
+            dataSource={lessons}
+            renderItem={lesson => (
+              <List.Item>
+                <Card title={`第 ${lesson.lessonOrder} 章: ${lesson.title}`}>
+                  <div dangerouslySetInnerHTML={{ __html: lesson.content }} />
+                </Card>
+              </List.Item>
+            )}
+          />
+        </div>
+      </Content>
+    </MainLayout>
+  );
+};
+
+export default CourseDetailPage;

--- a/chs-frontend/src/pages/CourseLibraryPage.js
+++ b/chs-frontend/src/pages/CourseLibraryPage.js
@@ -1,0 +1,55 @@
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { Layout, Typography, Card, Row, Col, Spin, Alert } from 'antd';
+import MainLayout from '../layouts/MainLayout';
+import courseService from '../services/courseService';
+
+const { Title } = Typography;
+const { Content } = Layout;
+
+const CourseLibraryPage = () => {
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    courseService.getAllCourses()
+      .then(response => {
+        setCourses(response.data);
+        setLoading(false);
+      })
+      .catch(error => {
+        console.error("Failed to fetch courses:", error);
+        setError("无法加载课程列表，请稍后再试。");
+        setLoading(false);
+      });
+  }, []);
+
+  return (
+    <MainLayout>
+      <Content style={{ padding: '50px' }}>
+        <Title level={2}>精品课程库</Title>
+        <p>在这里，您可以系统性地学习智慧水务领域的专业知识，从理论基础到项目实践。</p>
+
+        {loading && <Spin tip="加载中..." size="large" />}
+        {error && <Alert message="错误" description={error} type="error" showIcon />}
+
+        {!loading && !error && (
+          <Row gutter={[16, 16]} style={{ marginTop: '24px' }}>
+            {courses.map(course => (
+              <Col span={8} key={course.id}>
+                <Link to={`/courses/${course.id}`}>
+                  <Card title={course.title} hoverable>
+                    {course.description}
+                  </Card>
+                </Link>
+              </Col>
+            ))}
+          </Row>
+        )}
+      </Content>
+    </MainLayout>
+  );
+};
+
+export default CourseLibraryPage;

--- a/chs-frontend/src/pages/KnowledgeGraphPage.js
+++ b/chs-frontend/src/pages/KnowledgeGraphPage.js
@@ -1,0 +1,85 @@
+import React, { useCallback, useEffect } from 'react';
+import ReactFlow, {
+  MiniMap,
+  Controls,
+  Background,
+  useNodesState,
+  useEdgesState,
+  addEdge,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import MainLayout from '../layouts/MainLayout';
+import { Layout, Typography } from 'antd';
+import useKnowledgeGraphStore from '../store/useKnowledgeGraphStore';
+
+const { Title } = Typography;
+const { Content } = Layout;
+
+const initialNodes = [
+  { id: '1', position: { x: 0, y: 0 }, data: { label: '智慧水利' } },
+  { id: '2', position: { x: 0, y: 100 }, data: { label: '水系统感知' } },
+  { id: '3', position: { x: 200, y: 100 }, data: { label: '水系统仿真' } },
+  { id: '4', position: { x: -200, y: 200 }, data: { label: '卡尔曼滤波' } },
+  { id: '5', position: { x: 0, y: 200 }, data: { label: 'PID控制' } },
+];
+
+const initialEdges = [
+  { id: 'e1-2', source: '1', target: '2', label: '包含' },
+  { id: 'e1-3', source: '1', target: '3', label: '包含' },
+  { id: 'e2-4', source: '2', target: '4', label: '应用' },
+  { id: 'e3-5', source: '3', target: '5', label: '应用' },
+];
+
+const KnowledgeGraphPage = () => {
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+  const { highlightedNodeId, clearHighlight } = useKnowledgeGraphStore();
+
+  useEffect(() => {
+    setNodes((nds) =>
+      nds.map((node) => {
+        if (node.id === highlightedNodeId) {
+          return {
+            ...node,
+            style: { ...node.style, backgroundColor: '#2f80ed', color: 'white' },
+          };
+        }
+        return { ...node, style: { ...node.style, backgroundColor: undefined, color: undefined }};
+      })
+    );
+  }, [highlightedNodeId, setNodes]);
+
+  // Clean up highlight when leaving the page
+  useEffect(() => {
+    return () => {
+      clearHighlight();
+    };
+  }, [clearHighlight]);
+
+  const onConnect = useCallback(
+    (params) => setEdges((eds) => addEdge(params, eds)),
+    [setEdges],
+  );
+
+  return (
+    <MainLayout>
+      <Content style={{ padding: '0', height: 'calc(100vh - 112px)' }}>
+        <Title level={2} style={{ padding: '24px' }}>知识图谱浏览器</Title>
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onConnect={onConnect}
+          fitView
+        >
+          <Controls />
+          <MiniMap />
+          <Background variant="dots" gap={12} size={1} />
+        </ReactFlow>
+      </Content>
+    </MainLayout>
+  );
+};
+
+export default KnowledgeGraphPage;

--- a/chs-frontend/src/services/codeAssetService.js
+++ b/chs-frontend/src/services/codeAssetService.js
@@ -1,0 +1,28 @@
+import axios from 'axios';
+
+const API_URL = '/api/assets';
+
+const getAllCodeSnippets = () => {
+  return axios.get(`${API_URL}/snippets`);
+};
+
+const getCodeSnippetById = (id) => {
+  return axios.get(`${API_URL}/snippets/${id}`);
+};
+
+const getAllNotebooks = () => {
+  return axios.get(`${API_URL}/notebooks`);
+};
+
+const getNotebookById = (id) => {
+  return axios.get(`${API_URL}/notebooks/${id}`);
+};
+
+const codeAssetService = {
+  getAllCodeSnippets,
+  getCodeSnippetById,
+  getAllNotebooks,
+  getNotebookById,
+};
+
+export default codeAssetService;

--- a/chs-frontend/src/services/courseService.js
+++ b/chs-frontend/src/services/courseService.js
@@ -1,0 +1,23 @@
+import axios from 'axios';
+
+const API_URL = '/api/courses';
+
+const getAllCourses = () => {
+  return axios.get(API_URL);
+};
+
+const getCourseById = (id) => {
+  return axios.get(`${API_URL}/${id}`);
+};
+
+const getLessonsByCourseId = (courseId) => {
+  return axios.get(`${API_URL}/${courseId}/lessons`);
+};
+
+const courseService = {
+  getAllCourses,
+  getCourseById,
+  getLessonsByCourseId,
+};
+
+export default courseService;

--- a/chs-frontend/src/store/useKnowledgeGraphStore.js
+++ b/chs-frontend/src/store/useKnowledgeGraphStore.js
@@ -1,0 +1,9 @@
+import { create } from 'zustand';
+
+const useKnowledgeGraphStore = create((set) => ({
+  highlightedNodeId: null,
+  setHighlightedNodeId: (nodeId) => set({ highlightedNodeId: nodeId }),
+  clearHighlight: () => set({ highlightedNodeId: null }),
+}));
+
+export default useKnowledgeGraphStore;

--- a/src/main/java/com/chs/backend/controllers/CodeAssetController.java
+++ b/src/main/java/com/chs/backend/controllers/CodeAssetController.java
@@ -1,0 +1,45 @@
+package com.chs.backend.controllers;
+
+import com.chs.backend.models.CodeSnippet;
+import com.chs.backend.models.Notebook;
+import com.chs.backend.services.CodeAssetService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/assets")
+public class CodeAssetController {
+
+    @Autowired
+    private CodeAssetService codeAssetService;
+
+    @GetMapping("/snippets")
+    public List<CodeSnippet> getAllCodeSnippets() {
+        return codeAssetService.getAllCodeSnippets();
+    }
+
+    @GetMapping("/snippets/{id}")
+    public ResponseEntity<CodeSnippet> getCodeSnippetById(@PathVariable Long id) {
+        return codeAssetService.getCodeSnippetById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/notebooks")
+    public List<Notebook> getAllNotebooks() {
+        return codeAssetService.getAllNotebooks();
+    }
+
+    @GetMapping("/notebooks/{id}")
+    public ResponseEntity<Notebook> getNotebookById(@PathVariable Long id) {
+        return codeAssetService.getNotebookById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/chs/backend/controllers/CourseController.java
+++ b/src/main/java/com/chs/backend/controllers/CourseController.java
@@ -1,0 +1,35 @@
+package com.chs.backend.controllers;
+
+import com.chs.backend.models.Course;
+import com.chs.backend.models.Lesson;
+import com.chs.backend.services.CourseService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/courses")
+public class CourseController {
+
+    @Autowired
+    private CourseService courseService;
+
+    @GetMapping
+    public List<Course> getAllCourses() {
+        return courseService.getAllCourses();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Course> getCourseById(@PathVariable Long id) {
+        return courseService.getCourseById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{courseId}/lessons")
+    public List<Lesson> getLessonsByCourseId(@PathVariable Long courseId) {
+        return courseService.getLessonsByCourseId(courseId);
+    }
+}

--- a/src/main/java/com/chs/backend/controllers/ModelRegistryController.java
+++ b/src/main/java/com/chs/backend/controllers/ModelRegistryController.java
@@ -5,6 +5,7 @@ import com.chs.backend.models.ModelVersion;
 import com.chs.backend.payload.ModelDefinitionRequest;
 import com.chs.backend.payload.ModelVersionRequest;
 import com.chs.backend.security.UserPrincipal;
+import com.chs.backend.services.ModelDeploymentService;
 import com.chs.backend.services.ModelRegistryService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/chs/backend/controllers/SimulationController.java
+++ b/src/main/java/com/chs/backend/controllers/SimulationController.java
@@ -1,11 +1,12 @@
 package com.chs.backend.controllers;
 
-import com.chs.backend.models.SimulationRun;
+import com.chs.backend.payload.SimulationRunDTO;
 import com.chs.backend.payload.SimulationRequest;
 import com.chs.backend.security.UserPrincipal;
 import com.chs.backend.services.SimulationService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -18,15 +19,15 @@ public class SimulationController {
     private SimulationService simulationService;
 
     @PostMapping("/projects/{projectId}/simulations")
-    public ResponseEntity<SimulationRun> submitSimulation(@PathVariable Long projectId,
-                                                          @Valid @RequestBody SimulationRequest simulationRequest,
-                                                          @AuthenticationPrincipal UserPrincipal currentUser) {
-        SimulationRun simulationRun = simulationService.createAndRunSimulation(projectId, simulationRequest, currentUser.getUser());
-        return ResponseEntity.ok(simulationRun);
+    public ResponseEntity<SimulationRunDTO> submitSimulation(@PathVariable Long projectId,
+                                                           @Valid @RequestBody SimulationRequest simulationRequest,
+                                                           @AuthenticationPrincipal UserPrincipal currentUser) {
+        SimulationRunDTO simulationRunDTO = simulationService.createAndRunSimulation(projectId, simulationRequest, currentUser.getUser());
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(simulationRunDTO);
     }
 
     @GetMapping("/simulations/{id}")
-    public ResponseEntity<SimulationRun> getSimulation(@PathVariable Long id, @AuthenticationPrincipal UserPrincipal currentUser) {
+    public ResponseEntity<SimulationRunDTO> getSimulation(@PathVariable Long id, @AuthenticationPrincipal UserPrincipal currentUser) {
         return simulationService.getSimulationRunById(id, currentUser.getUser())
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());

--- a/src/main/java/com/chs/backend/models/CodeSnippet.java
+++ b/src/main/java/com/chs/backend/models/CodeSnippet.java
@@ -1,0 +1,80 @@
+package com.chs.backend.models;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "code_snippets")
+public class CodeSnippet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String code;
+
+    @Column(nullable = false)
+    private String language;
+
+    // Getters and Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CodeSnippet that = (CodeSnippet) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/chs/backend/models/Course.java
+++ b/src/main/java/com/chs/backend/models/Course.java
@@ -1,0 +1,71 @@
+package com.chs.backend.models;
+
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "courses")
+public class Course {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Lesson> lessons = new ArrayList<>();
+
+    // Getters and Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<Lesson> getLessons() {
+        return lessons;
+    }
+
+    public void setLessons(List<Lesson> lessons) {
+        this.lessons = lessons;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Course course = (Course) o;
+        return Objects.equals(id, course.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/chs/backend/models/Lesson.java
+++ b/src/main/java/com/chs/backend/models/Lesson.java
@@ -1,0 +1,81 @@
+package com.chs.backend.models;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "lessons")
+public class Lesson {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "lesson_order")
+    private int lessonOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    // Getters and Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public int getLessonOrder() {
+        return lessonOrder;
+    }
+
+    public void setLessonOrder(int lessonOrder) {
+        this.lessonOrder = lessonOrder;
+    }
+
+    public Course getCourse() {
+        return course;
+    }
+
+    public void setCourse(Course course) {
+        this.course = course;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Lesson lesson = (Lesson) o;
+        return Objects.equals(id, lesson.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/chs/backend/models/Notebook.java
+++ b/src/main/java/com/chs/backend/models/Notebook.java
@@ -1,0 +1,69 @@
+package com.chs.backend.models;
+
+import jakarta.persistence.*;
+import java.util.Objects;
+
+@Entity
+@Table(name = "notebooks")
+public class Notebook {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content; // Storing notebook content as a JSON string
+
+    // Getters and Setters
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Notebook notebook = (Notebook) o;
+        return Objects.equals(id, notebook.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/chs/backend/models/UserProgress.java
+++ b/src/main/java/com/chs/backend/models/UserProgress.java
@@ -1,0 +1,83 @@
+package com.chs.backend.models;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "user_progress")
+public class UserProgress {
+
+    @EmbeddedId
+    private UserProgressId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("userId")
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("lessonId")
+    @JoinColumn(name = "lesson_id")
+    private Lesson lesson;
+
+    @Column(name = "completed_at", nullable = false)
+    private LocalDateTime completedAt;
+
+    // Constructors, Getters, and Setters
+
+    public UserProgress() {
+    }
+
+    public UserProgress(User user, Lesson lesson) {
+        this.user = user;
+        this.lesson = lesson;
+        this.id = new UserProgressId(user.getId(), lesson.getId());
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public UserProgressId getId() {
+        return id;
+    }
+
+    public void setId(UserProgressId id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Lesson getLesson() {
+        return lesson;
+    }
+
+    public void setLesson(Lesson lesson) {
+        this.lesson = lesson;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserProgress that = (UserProgress) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/com/chs/backend/models/UserProgressId.java
+++ b/src/main/java/com/chs/backend/models/UserProgressId.java
@@ -1,0 +1,52 @@
+package com.chs.backend.models;
+
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+public class UserProgressId implements Serializable {
+
+    private Long userId;
+    private Long lessonId;
+
+    // Constructors, Getters, Setters, equals, hashCode
+
+    public UserProgressId() {
+    }
+
+    public UserProgressId(Long userId, Long lessonId) {
+        this.userId = userId;
+        this.lessonId = lessonId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public Long getLessonId() {
+        return lessonId;
+    }
+
+    public void setLessonId(Long lessonId) {
+        this.lessonId = lessonId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserProgressId that = (UserProgressId) o;
+        return Objects.equals(userId, that.userId) &&
+               Objects.equals(lessonId, that.lessonId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, lessonId);
+    }
+}

--- a/src/main/java/com/chs/backend/payload/ProjectDTO.java
+++ b/src/main/java/com/chs/backend/payload/ProjectDTO.java
@@ -1,0 +1,38 @@
+package com.chs.backend.payload;
+
+public class ProjectDTO {
+    private Long id;
+    private String name;
+    private UserDTO user;
+
+    public ProjectDTO(Long id, String name, UserDTO user) {
+        this.id = id;
+        this.name = name;
+        this.user = user;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public UserDTO getUser() {
+        return user;
+    }
+
+    public void setUser(UserDTO user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/chs/backend/payload/SimulationRunDTO.java
+++ b/src/main/java/com/chs/backend/payload/SimulationRunDTO.java
@@ -1,0 +1,66 @@
+package com.chs.backend.payload;
+
+import com.chs.backend.models.SimulationStatus;
+
+import java.time.LocalDateTime;
+
+public class SimulationRunDTO {
+    private Long id;
+    private ProjectDTO project;
+    private SimulationStatus status;
+    private LocalDateTime createdAt;
+    private LocalDateTime completedAt;
+
+    // Constructors, Getters, and Setters
+
+    public SimulationRunDTO() {
+    }
+
+    public SimulationRunDTO(Long id, ProjectDTO project, SimulationStatus status, LocalDateTime createdAt, LocalDateTime completedAt) {
+        this.id = id;
+        this.project = project;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.completedAt = completedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public ProjectDTO getProject() {
+        return project;
+    }
+
+    public void setProject(ProjectDTO project) {
+        this.project = project;
+    }
+
+    public SimulationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(SimulationStatus status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getCompletedAt() {
+        return completedAt;
+    }
+
+    public void setCompletedAt(LocalDateTime completedAt) {
+        this.completedAt = completedAt;
+    }
+}

--- a/src/main/java/com/chs/backend/payload/UserDTO.java
+++ b/src/main/java/com/chs/backend/payload/UserDTO.java
@@ -1,0 +1,38 @@
+package com.chs.backend.payload;
+
+public class UserDTO {
+    private Long id;
+    private String username;
+    private String email;
+
+    public UserDTO(Long id, String username, String email) {
+        this.id = id;
+        this.username = username;
+        this.email = email;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/src/main/java/com/chs/backend/repositories/CodeSnippetRepository.java
+++ b/src/main/java/com/chs/backend/repositories/CodeSnippetRepository.java
@@ -1,0 +1,9 @@
+package com.chs.backend.repositories;
+
+import com.chs.backend.models.CodeSnippet;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CodeSnippetRepository extends JpaRepository<CodeSnippet, Long> {
+}

--- a/src/main/java/com/chs/backend/repositories/CourseRepository.java
+++ b/src/main/java/com/chs/backend/repositories/CourseRepository.java
@@ -1,0 +1,9 @@
+package com.chs.backend.repositories;
+
+import com.chs.backend.models.Course;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CourseRepository extends JpaRepository<Course, Long> {
+}

--- a/src/main/java/com/chs/backend/repositories/LessonRepository.java
+++ b/src/main/java/com/chs/backend/repositories/LessonRepository.java
@@ -1,0 +1,12 @@
+package com.chs.backend.repositories;
+
+import com.chs.backend.models.Lesson;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface LessonRepository extends JpaRepository<Lesson, Long> {
+    List<Lesson> findByCourseIdOrderByLessonOrderAsc(Long courseId);
+}

--- a/src/main/java/com/chs/backend/repositories/NotebookRepository.java
+++ b/src/main/java/com/chs/backend/repositories/NotebookRepository.java
@@ -1,0 +1,9 @@
+package com.chs.backend.repositories;
+
+import com.chs.backend.models.Notebook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NotebookRepository extends JpaRepository<Notebook, Long> {
+}

--- a/src/main/java/com/chs/backend/repositories/UserProgressRepository.java
+++ b/src/main/java/com/chs/backend/repositories/UserProgressRepository.java
@@ -1,0 +1,10 @@
+package com.chs.backend.repositories;
+
+import com.chs.backend.models.UserProgress;
+import com.chs.backend.models.UserProgressId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserProgressRepository extends JpaRepository<UserProgress, UserProgressId> {
+}

--- a/src/main/java/com/chs/backend/security/CurrentUser.java
+++ b/src/main/java/com/chs/backend/security/CurrentUser.java
@@ -1,0 +1,11 @@
+package com.chs.backend.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+}

--- a/src/main/java/com/chs/backend/services/CodeAssetService.java
+++ b/src/main/java/com/chs/backend/services/CodeAssetService.java
@@ -1,0 +1,39 @@
+package com.chs.backend.services;
+
+import com.chs.backend.models.CodeSnippet;
+import com.chs.backend.models.Notebook;
+import com.chs.backend.repositories.CodeSnippetRepository;
+import com.chs.backend.repositories.NotebookRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CodeAssetService {
+
+    @Autowired
+    private CodeSnippetRepository codeSnippetRepository;
+
+    @Autowired
+    private NotebookRepository notebookRepository;
+
+    public List<CodeSnippet> getAllCodeSnippets() {
+        return codeSnippetRepository.findAll();
+    }
+
+    public Optional<CodeSnippet> getCodeSnippetById(Long id) {
+        return codeSnippetRepository.findById(id);
+    }
+
+    public List<Notebook> getAllNotebooks() {
+        return notebookRepository.findAll();
+    }
+
+    public Optional<Notebook> getNotebookById(Long id) {
+        return notebookRepository.findById(id);
+    }
+
+    // Methods for creating/updating assets can be added later
+}

--- a/src/main/java/com/chs/backend/services/CourseService.java
+++ b/src/main/java/com/chs/backend/services/CourseService.java
@@ -1,0 +1,37 @@
+package com.chs.backend.services;
+
+import com.chs.backend.models.Course;
+import com.chs.backend.models.Lesson;
+import com.chs.backend.repositories.CourseRepository;
+import com.chs.backend.repositories.LessonRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CourseService {
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private LessonRepository lessonRepository;
+
+    public List<Course> getAllCourses() {
+        return courseRepository.findAll();
+    }
+
+    public Optional<Course> getCourseById(Long id) {
+        return courseRepository.findById(id);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Lesson> getLessonsByCourseId(Long courseId) {
+        return lessonRepository.findByCourseIdOrderByLessonOrderAsc(courseId);
+    }
+
+    // Additional methods for creating/updating courses and lessons can be added later
+}

--- a/src/main/java/com/chs/backend/services/ModelDeploymentServiceImpl.java
+++ b/src/main/java/com/chs/backend/services/ModelDeploymentServiceImpl.java
@@ -12,7 +12,7 @@ public class ModelDeploymentServiceImpl implements ModelDeploymentService {
 
     @Override
     public void deploy(ModelVersion modelVersion) {
-        logger.info("Placeholder: Deploying model version {} with Docker image {}", modelVersion.getVersionTag(), modelVersion.getDockerImage());
+        logger.info("Placeholder: Deploying model version {} with Docker image {}", modelVersion.getVersionTag(), modelVersion.getDockerImageUri());
         // In a real implementation, this would call a container orchestration API (e.g., Kubernetes)
     }
 

--- a/src/test/java/com/chs/backend/SimulationIntegrationTest.java
+++ b/src/test/java/com/chs/backend/SimulationIntegrationTest.java
@@ -4,11 +4,14 @@ import com.chs.backend.models.*;
 import com.chs.backend.payload.LoginRequest;
 import com.chs.backend.payload.RegisterRequest;
 import com.chs.backend.payload.SimulationRequest;
+import com.chs.backend.payload.SimulationRunDTO;
 import com.chs.backend.repositories.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.*;
@@ -43,6 +46,9 @@ public class SimulationIntegrationTest {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @MockBean
+    private RabbitTemplate rabbitTemplate;
 
     private String token;
 
@@ -91,14 +97,14 @@ public class SimulationIntegrationTest {
         headers.setBearerAuth(token);
         HttpEntity<SimulationRequest> entity = new HttpEntity<>(simulationRequest, headers);
 
-        ResponseEntity<SimulationRun> response = restTemplate.exchange(
+        ResponseEntity<SimulationRunDTO> response = restTemplate.exchange(
                 "http://localhost:" + port + "/api/projects/" + project.getId() + "/simulations",
                 HttpMethod.POST,
                 entity,
-                SimulationRun.class
+                SimulationRunDTO.class
         );
 
-        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(HttpStatus.ACCEPTED, response.getStatusCode());
         assertEquals(project.getId(), response.getBody().getProject().getId());
     }
 }

--- a/src/test/java/com/chs/backend/services/CodeAssetServiceTest.java
+++ b/src/test/java/com/chs/backend/services/CodeAssetServiceTest.java
@@ -1,0 +1,82 @@
+package com.chs.backend.services;
+
+import com.chs.backend.models.CodeSnippet;
+import com.chs.backend.models.Notebook;
+import com.chs.backend.repositories.CodeSnippetRepository;
+import com.chs.backend.repositories.NotebookRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CodeAssetServiceTest {
+
+    @Mock
+    private CodeSnippetRepository codeSnippetRepository;
+
+    @Mock
+    private NotebookRepository notebookRepository;
+
+    @InjectMocks
+    private CodeAssetService codeAssetService;
+
+    private CodeSnippet snippet;
+    private Notebook notebook;
+
+    @BeforeEach
+    void setUp() {
+        snippet = new CodeSnippet();
+        snippet.setId(1L);
+        snippet.setTitle("Test Snippet");
+
+        notebook = new Notebook();
+        notebook.setId(1L);
+        notebook.setTitle("Test Notebook");
+    }
+
+    @Test
+    void testGetAllCodeSnippets() {
+        when(codeSnippetRepository.findAll()).thenReturn(Collections.singletonList(snippet));
+        List<CodeSnippet> result = codeAssetService.getAllCodeSnippets();
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(codeSnippetRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetCodeSnippetById() {
+        when(codeSnippetRepository.findById(1L)).thenReturn(Optional.of(snippet));
+        Optional<CodeSnippet> result = codeAssetService.getCodeSnippetById(1L);
+        assertTrue(result.isPresent());
+        assertEquals("Test Snippet", result.get().getTitle());
+        verify(codeSnippetRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void testGetAllNotebooks() {
+        when(notebookRepository.findAll()).thenReturn(Collections.singletonList(notebook));
+        List<Notebook> result = codeAssetService.getAllNotebooks();
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(notebookRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetNotebookById() {
+        when(notebookRepository.findById(1L)).thenReturn(Optional.of(notebook));
+        Optional<Notebook> result = codeAssetService.getNotebookById(1L);
+        assertTrue(result.isPresent());
+        assertEquals("Test Notebook", result.get().getTitle());
+        verify(notebookRepository, times(1)).findById(1L);
+    }
+}

--- a/src/test/java/com/chs/backend/services/CourseServiceTest.java
+++ b/src/test/java/com/chs/backend/services/CourseServiceTest.java
@@ -1,0 +1,96 @@
+package com.chs.backend.services;
+
+import com.chs.backend.models.Course;
+import com.chs.backend.models.Lesson;
+import com.chs.backend.repositories.CourseRepository;
+import com.chs.backend.repositories.LessonRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CourseServiceTest {
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private LessonRepository lessonRepository;
+
+    @InjectMocks
+    private CourseService courseService;
+
+    private Course course1;
+    private Course course2;
+    private Lesson lesson1;
+
+    @BeforeEach
+    void setUp() {
+        course1 = new Course();
+        course1.setId(1L);
+        course1.setTitle("Test Course 1");
+
+        course2 = new Course();
+        course2.setId(2L);
+        course2.setTitle("Test Course 2");
+
+        lesson1 = new Lesson();
+        lesson1.setId(101L);
+        lesson1.setTitle("Test Lesson 1");
+        lesson1.setCourse(course1);
+    }
+
+    @Test
+    void testGetAllCourses() {
+        when(courseRepository.findAll()).thenReturn(Arrays.asList(course1, course2));
+
+        List<Course> courses = courseService.getAllCourses();
+
+        assertNotNull(courses);
+        assertEquals(2, courses.size());
+        verify(courseRepository, times(1)).findAll();
+    }
+
+    @Test
+    void testGetCourseById_found() {
+        when(courseRepository.findById(1L)).thenReturn(Optional.of(course1));
+
+        Optional<Course> result = courseService.getCourseById(1L);
+
+        assertTrue(result.isPresent());
+        assertEquals("Test Course 1", result.get().getTitle());
+        verify(courseRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    void testGetCourseById_notFound() {
+        when(courseRepository.findById(99L)).thenReturn(Optional.empty());
+
+        Optional<Course> result = courseService.getCourseById(99L);
+
+        assertFalse(result.isPresent());
+        verify(courseRepository, times(1)).findById(99L);
+    }
+
+    @Test
+    void testGetLessonsByCourseId() {
+        when(lessonRepository.findByCourseIdOrderByLessonOrderAsc(1L)).thenReturn(List.of(lesson1));
+
+        List<Lesson> lessons = courseService.getLessonsByCourseId(1L);
+
+        assertNotNull(lessons);
+        assertEquals(1, lessons.size());
+        assertEquals("Test Lesson 1", lessons.get(0).getTitle());
+        verify(lessonRepository, times(1)).findByCourseIdOrderByLessonOrderAsc(1L);
+    }
+}


### PR DESCRIPTION
This commit introduces the core features of the Knowledge Ecosystem Platform, building out the backend infrastructure and the user-facing frontend components for courses, code assets, and the knowledge graph.

On the backend, new JPA entities (`Course`, `Lesson`, `CodeSnippet`, `Notebook`, `UserProgress`) and their corresponding Spring Data repositories have been created. Services and REST controllers (`CourseController`, `CodeAssetController`) expose this data through a public API.

On the frontend, several new React pages have been developed:
- `CourseLibraryPage`: Displays a list of available courses.
- `CourseDetailPage`: Shows the lessons within a specific course.
- `CodeAssetLibraryPage`: A gallery for code snippets and notebooks.
- `KnowledgeGraphPage`: An interactive viewer for the knowledge graph, built with ReactFlow.

A key feature is the deep-linking capability between course content and the knowledge graph, which is managed via a `Zustand` global state store. This allows clicking on a term in a lesson to highlight the corresponding node in the graph.

Additionally, this commit includes fixes for several pre-existing issues in the codebase that were discovered during testing:
- Resolved multiple Java compilation errors.
- Fixed a failing integration test (`SimulationIntegrationTest`) by mocking the `RabbitTemplate` to remove the dependency on a running RabbitMQ instance and by introducing DTOs to solve a Hibernate lazy-loading serialization error.
- Added new unit tests for the `CourseService` and `CodeAssetService`.