### PR TITLE
feat: Implement core architecture for multi-fidelity models

### DIFF
--- a/examples/4_one_gate_one_channel_case/topology.yml
+++ b/examples/4_one_gate_one_channel_case/topology.yml
@@ -4,17 +4,33 @@
 components:
   - name: inflow_to_channel
     type: Disturbance
+    properties:
+      signal_type: "constant"
+      value: 10.0
 
   - name: channel
-    type: MuskingumChannelModel
-    properties:
-      K: 5.0
-      x: 0.1 # Corrected for stability
-      dt: 1.0
-      initial_inflow: 10.0
-      initial_outflow: 10.0
-    connections:
-      inflow: inflow_to_channel.output
+    type: ChannelEntity
+    properties: {} # No entity-level properties for now
+
+    # Define the three fidelity models for the channel
+    steady_model:
+      type: SteadyChannelModel
+      properties: {} # No params for the placeholder
+
+    dynamic_model:
+      type: MuskingumChannelModel
+      properties:
+        K: 5.0
+        x: 0.1 # Corrected for stability
+        dt: 1.0
+        initial_inflow: 10.0
+        initial_outflow: 10.0
+      connections:
+        inflow: inflow_to_channel.output
+
+    precision_model:
+      type: StVenantModel
+      properties: {} # No params for the placeholder
 
   - name: pid_controller
     type: PIDController

--- a/run_case.py
+++ b/run_case.py
@@ -1,0 +1,73 @@
+import argparse
+import yaml
+import pandas as pd
+import os
+from water_system_simulator.simulation_manager import SimulationManager
+
+def main():
+    """
+    A generic command-line runner for CHS simulation cases.
+    """
+    parser = argparse.ArgumentParser(description="Run a CHS simulation case from a YAML file.")
+    parser.add_argument(
+        "yaml_path",
+        type=str,
+        help="Path to the simulation topology YAML file."
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="DYNAMIC",
+        choices=["STEADY", "DYNAMIC", "PRECISION"],
+        help="The simulation fidelity mode to run."
+    )
+    args = parser.parse_args()
+
+    print(f"--- Loading simulation from: {args.yaml_path} ---")
+    try:
+        with open(args.yaml_path, 'r') as f:
+            config = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Error: Configuration file not found at '{args.yaml_path}'")
+        return
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML file: {e}")
+        return
+
+    # --- Check for and merge control parameters ---
+    case_dir = os.path.dirname(args.yaml_path)
+    control_params_path = os.path.join(case_dir, 'control_parameters.yaml')
+    if os.path.exists(control_params_path):
+        print(f"--- Loading control parameters from: {control_params_path} ---")
+        with open(control_params_path, 'r') as f:
+            control_params = yaml.safe_load(f)
+
+        # Merge control params into the main config
+        if 'pid_params' in control_params:
+            for component in config.get('components', []):
+                if component.get('name') == 'pid_controller':
+                    if 'properties' not in component:
+                        component['properties'] = {}
+                    component['properties'].update(control_params['pid_params'])
+                    print(f"Merged 'pid_params' into 'pid_controller'")
+                    break # Found and updated, no need to continue loop
+
+    print(f"--- Initializing SimulationManager in {args.mode} mode ---")
+    try:
+        # The manager now handles config loading and preprocessing internally
+        manager = SimulationManager(config=config)
+
+        print("--- Running simulation ---")
+        results_df = manager.run(mode=args.mode)
+
+        print("\n--- Simulation Finished ---")
+        print("Results (first 5 rows):")
+        print(results_df.head())
+
+    except Exception as e:
+        print(f"\nAn error occurred during simulation: {e}")
+        # Optionally, re-raise for debugging
+        # raise
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_architecture.py
+++ b/tests/unit/test_architecture.py
@@ -1,0 +1,140 @@
+import unittest
+import pandas as pd
+from water_system_simulator.modeling.base_model import BaseModel
+from water_system_simulator.modeling.base_physical_entity import BasePhysicalEntity
+from water_system_simulator.simulation_manager import SimulationManager
+from water_system_simulator.core.simulation_modes import SimulationMode
+
+# --- Mock Models for Testing ---
+
+class MockSteadyModel(BaseModel):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.called = False
+        self.output = 1.0
+
+    def solve(self, **kwargs):
+        self.called = True
+
+    def step(self, **kwargs):
+        # This should not be called for a steady model
+        pass
+
+    def get_state(self):
+        return {"state": "steady"}
+
+class MockDynamicModel(BaseModel):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.called = False
+        self.output = 2.0
+
+    def step(self, **kwargs):
+        self.called = True
+
+    def get_state(self):
+        return {"state": "dynamic"}
+
+class MockPrecisionModel(BaseModel):
+    def __init__(self, **kwargs):
+        super().__init__()
+        self.called = False
+        self.output = 3.0
+
+    def step(self, **kwargs):
+        self.called = True
+
+    def get_state(self):
+        return {"state": "precision"}
+
+# --- Test Case ---
+
+class TestArchitecture(unittest.TestCase):
+    def setUp(self):
+        """Set up the test environment."""
+        self.sm = SimulationManager()
+        # We need to import the registry to modify it for the test
+        from water_system_simulator.simulation_manager import ComponentRegistry
+
+        # Add mock models and the entity to the registry for this test
+        ComponentRegistry._CLASS_MAP['MockSteadyModel'] = f"{__name__}.MockSteadyModel"
+        ComponentRegistry._CLASS_MAP['MockDynamicModel'] = f"{__name__}.MockDynamicModel"
+        ComponentRegistry._CLASS_MAP['MockPrecisionModel'] = f"{__name__}.MockPrecisionModel"
+        # The BasePhysicalEntity is already in the map, but we ensure it's correct for the test's context
+        ComponentRegistry._CLASS_MAP['BasePhysicalEntity'] = "water_system_simulator.modeling.base_physical_entity.BasePhysicalEntity"
+
+        self.config = {
+            "components": {
+                "test_entity": {
+                    "type": "BasePhysicalEntity",
+                    "params": {},
+                    "steady_model": {
+                        "type": "MockSteadyModel",
+                        "params": {}
+                    },
+                    "dynamic_model": {
+                        "type": "MockDynamicModel",
+                        "params": {}
+                    },
+                    "precision_model": {
+                        "type": "MockPrecisionModel",
+                        "params": {}
+                    }
+                }
+            },
+            "simulation_params": {"total_time": 2, "dt": 1},
+            "execution_order": ["test_entity"],
+            "logger_config": ["test_entity.output"]
+        }
+
+    def test_entity_model_delegation(self):
+        """
+        Tests that the SimulationManager correctly builds a PhysicalEntity
+        and that the entity correctly delegates calls to the appropriate model
+        based on the simulation mode.
+        """
+        # --- Test DYNAMIC mode ---
+        results_dyn = self.sm.run(self.config, mode="DYNAMIC")
+        entity_dyn = self.sm.components["test_entity"]
+
+        self.assertIsInstance(entity_dyn, BasePhysicalEntity)
+        self.assertTrue(entity_dyn.dynamic_model.called, "Dynamic model should have been called")
+        self.assertFalse(entity_dyn.steady_model.called, "Steady model should NOT have been called in DYNAMIC mode")
+        self.assertFalse(entity_dyn.precision_model.called, "Precision model should NOT have been called in DYNAMIC mode")
+        self.assertEqual(entity_dyn.output, 2.0)
+        self.assertEqual(results_dyn['test_entity.output'].iloc[-1], 2.0)
+
+        # --- Test STEADY mode ---
+        # Reset called flags
+        entity_dyn.steady_model.called = False
+        entity_dyn.dynamic_model.called = False
+        entity_dyn.precision_model.called = False
+
+        results_std = self.sm.run(self.config, mode="STEADY")
+        entity_std = self.sm.components["test_entity"]
+
+        self.assertTrue(entity_std.steady_model.called, "Steady model should have been called")
+        self.assertFalse(entity_std.dynamic_model.called, "Dynamic model should NOT have been called in STEADY mode")
+        self.assertFalse(entity_std.precision_model.called, "Precision model should NOT have been called in STEADY mode")
+        self.assertEqual(entity_std.output, 1.0)
+        self.assertEqual(results_std.shape[0], 1, "Steady simulation should only have one time step")
+        self.assertEqual(results_std['test_entity.output'].iloc[-1], 1.0)
+
+
+        # --- Test PRECISION mode ---
+        # Reset called flags
+        entity_std.steady_model.called = False
+        entity_std.dynamic_model.called = False
+        entity_std.precision_model.called = False
+
+        results_pre = self.sm.run(self.config, mode="PRECISION")
+        entity_pre = self.sm.components["test_entity"]
+
+        self.assertTrue(entity_pre.precision_model.called, "Precision model should have been called")
+        self.assertFalse(entity_pre.steady_model.called, "Steady model should NOT have been called in PRECISION mode")
+        self.assertFalse(entity_pre.dynamic_model.called, "Dynamic model should NOT have been called in PRECISION mode")
+        self.assertEqual(entity_pre.output, 3.0)
+        self.assertEqual(results_pre['test_entity.output'].iloc[-1], 3.0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/water_system_sdk/src/water_system_simulator/core/simulation_modes.py
+++ b/water_system_sdk/src/water_system_simulator/core/simulation_modes.py
@@ -1,0 +1,9 @@
+from enum import Enum, auto
+
+class SimulationMode(Enum):
+    """
+    Enumeration for the different simulation fidelity modes.
+    """
+    STEADY = auto()
+    DYNAMIC = auto()
+    PRECISION = auto() # Note: The user referred to this as TRANSIENT and PRECISION. Using PRECISION for the enum member name.

--- a/water_system_sdk/src/water_system_simulator/modeling/base_physical_entity.py
+++ b/water_system_sdk/src/water_system_simulator/modeling/base_physical_entity.py
@@ -1,0 +1,62 @@
+from typing import Optional
+from water_system_simulator.modeling.base_model import BaseModel
+from water_system_simulator.core.simulation_modes import SimulationMode
+
+class BasePhysicalEntity(BaseModel):
+    """
+    A container for managing and switching between different fidelity models
+    for a single physical object in the water system.
+    """
+    def __init__(self, name: str, steady_model: Optional[BaseModel] = None, dynamic_model: Optional[BaseModel] = None, precision_model: Optional[BaseModel] = None):
+        super().__init__()
+        self.name = name
+        self.steady_model = steady_model
+        self.dynamic_model = dynamic_model
+        self.precision_model = precision_model
+        self._active_model: Optional[BaseModel] = self.dynamic_model # Default to dynamic
+
+    def step(self, simulation_mode: SimulationMode = SimulationMode.DYNAMIC, **kwargs):
+        """
+        Delegates the step call to the appropriate internal model based on the
+        global simulation mode.
+
+        Args:
+            simulation_mode: The current simulation mode (STEADY, DYNAMIC, PRECISION).
+            **kwargs: Additional arguments to pass to the model's step/solve method.
+        """
+        if simulation_mode == SimulationMode.STEADY:
+            if not self.steady_model:
+                raise NotImplementedError(f"Entity '{self.name}' does not have a steady-state model.")
+            self._active_model = self.steady_model
+            # Per instructions, steady model has a `solve` method
+            if hasattr(self._active_model, 'solve'):
+                self._active_model.solve(**kwargs)
+            else:
+                raise AttributeError(f"Steady model for '{self.name}' does not have a 'solve' method.")
+
+        elif simulation_mode == SimulationMode.DYNAMIC:
+            if not self.dynamic_model:
+                raise NotImplementedError(f"Entity '{self.name}' does not have a dynamic model.")
+            self._active_model = self.dynamic_model
+            self._active_model.step(**kwargs)
+
+        elif simulation_mode == SimulationMode.PRECISION:
+            if not self.precision_model:
+                raise NotImplementedError(f"Entity '{self.name}' does not have a precision model.")
+            self._active_model = self.precision_model
+            self._active_model.step(**kwargs)
+
+        else:
+            raise ValueError(f"Unknown simulation mode: {simulation_mode}")
+
+        # The entity's output is the output of the active model
+        if self._active_model:
+            self.output = self._active_model.output
+
+    def get_state(self):
+        """
+        Returns the state of the currently active model.
+        """
+        if self._active_model:
+            return self._active_model.get_state()
+        return {"status": "no_active_model"}

--- a/water_system_sdk/src/water_system_simulator/modeling/entities/channel_entity.py
+++ b/water_system_sdk/src/water_system_simulator/modeling/entities/channel_entity.py
@@ -1,0 +1,11 @@
+from water_system_simulator.modeling.base_physical_entity import BasePhysicalEntity
+
+class ChannelEntity(BasePhysicalEntity):
+    """
+    Physical entity representing a river or canal channel.
+
+    This entity acts as a container for various fidelity models that simulate
+    flow through the channel.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/water_system_sdk/src/water_system_simulator/modeling/hydrodynamics/channel_models.py
+++ b/water_system_sdk/src/water_system_simulator/modeling/hydrodynamics/channel_models.py
@@ -1,0 +1,35 @@
+from water_system_simulator.modeling.base_model import BaseModel
+
+class SteadyChannelModel(BaseModel):
+    """
+    Placeholder for a steady-state channel model.
+    Based on the energy equation and standard step method.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.output = 0.0
+
+    def solve(self, **kwargs):
+        raise NotImplementedError("SteadyChannelModel is not yet implemented.")
+
+    def step(self, **kwargs):
+        # Steady model uses solve(), not step()
+        pass
+
+    def get_state(self):
+        return {"status": "not_implemented"}
+
+class StVenantModel(BaseModel):
+    """
+    Placeholder for a high-precision transient channel model.
+    Based on the full 1D Saint-Venant equations.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.output = 0.0
+
+    def step(self, **kwargs):
+        raise NotImplementedError("StVenantModel is not yet implemented.")
+
+    def get_state(self):
+        return {"status": "not_implemented"}


### PR DESCRIPTION
I've introduced the foundational architecture for supporting multi-fidelity (Steady, Dynamic, Precision) models, as the first step.

Here are the key changes I made:
- Created a `BasePhysicalEntity` class in `modeling/base_physical_entity.py` to serve as a container for different model fidelities. Its `step` method delegates calls to the appropriate sub-model based on the simulation mode.
- Added a `SimulationMode` enum in `core/simulation_modes.py` to standardize the modes (`STEADY`, `DYNAMIC`, `PRECISION`).
- Upgraded the `SimulationManager` to handle the new entity structure. The `_build_system` method can now parse a new configuration format with `steady_model`, `dynamic_model`, and `precision_model` keys, instantiating the entity and its models correctly.
- Added a `simulation_mode` parameter to the `run` method to control which fidelity model is executed.
- Created `tests/unit/test_architecture.py` with mock models to verify that the `SimulationManager` builds entities correctly and that the delegation logic works as expected.
- Refactored the existing channel component into a `ChannelEntity` as a proof-of-concept, updating the corresponding example YAML file (`examples/4_one_gate_one_channel_case/topology.yml`) to demonstrate the new structure.
- Created a generic runner script `run_case.py` to facilitate testing of YAML-based simulation cases.

I had to stop while attempting to run a full integration test on the refactored `4_one_gate_one_channel_case` example. The simulation repeatedly failed with a `TypeError: PIDController.__init__() missing 4 required positional arguments: 'Kp', 'Ki', 'Kd', and 'set_point'`.

This indicates a persistent issue with loading the PID controller's configuration. I suspect the root cause is a mismatch between the parameter names in the `control_parameters.yaml` file (e.g., `kp`, `setpoint`) and the argument names expected by the `PIDController` class constructor. My next step would have been to inspect the `PIDController` source code to confirm the exact `__init__` signature and correct the configuration files or the parameter merging logic accordingly.