### PR TITLE
feat: Implement Phase 2 dispatch and HITL features

### DIFF
--- a/chs-scada-dispatch/dispatch_engine/central_agent_executor.py
+++ b/chs-scada-dispatch/dispatch_engine/central_agent_executor.py
@@ -1,12 +1,14 @@
 import logging
 import time
 import threading
+import uuid
 from typing import Optional, Dict, Any
 
 # Mock Agent for simulation purposes
 class MockManagementAgent:
     """
-    A mock central agent that decides to adjust pump speed if pressure is too high.
+    A mock central agent that decides to adjust pump speed if pressure is too high,
+    and requests human intervention for moderately high pressure.
     This simulates a real agent from the 'chs-sdk'.
     """
     def execute(self, observation: Dict[str, Any]) -> Optional[Dict[str, Any]]:
@@ -14,55 +16,125 @@ class MockManagementAgent:
         Executes a decision based on the system-wide observation.
         """
         for device_id, status in observation.items():
-            # Example logic: If a pump station's pressure is above 120, reduce pump speed.
             pressure = status.get("values", {}).get("pressure_psi")
-            if pressure and pressure > 120:
-                logging.info(f"[Agent] High pressure detected at {device_id} ({pressure} psi). Deciding to reduce pump speed.")
+            if not pressure:
+                continue
+
+            # Condition 1: High pressure -> Automatic command
+            if pressure > 120:
+                logging.info(f"[Agent] High pressure at {device_id} ({pressure} psi). Proposing automatic command.")
                 return {
                     "action_type": "command",
                     "target_device_id": device_id,
-                    "command": {"set_pump_speed": 0.85}
+                    "command": {"set_pump_speed": 0.85},
+                    "description": f"Automatically reduce pump speed at {device_id} due to high pressure ({pressure} psi)."
                 }
+
+            # Condition 2: Moderately high pressure -> Request Human-in-the-Loop
+            if 110 <= pressure <= 120:
+                logging.info(f"[Agent] Moderate pressure at {device_id} ({pressure} psi). Proposing Human-in-the-Loop.")
+                return {
+                    "action_type": "human_in_the_loop",
+                    "request_id": str(uuid.uuid4()),
+                    "target_device_id": device_id,
+                    "proposed_command": {"set_pump_speed": 0.9},
+                    "description": f"Pressure at {device_id} is moderately high ({pressure} psi). Recommend reducing pump speed to 90%. Please confirm."
+                }
+
         return None # No action needed
 
 class CentralExecutor:
     """
-    Loads and executes a central-level intelligent agent for system-wide control.
+    Loads and executes a central-level intelligent agent for system-wide control,
+    including handling Human-in-the-Loop (HITL) decision flows.
     """
     def __init__(self, timeseries_db, mqtt_service, websocket_service=None):
         self.timeseries_db = timeseries_db
         self.mqtt_service = mqtt_service
-        self.websocket_service = websocket_service # For future HITL integration
+        self.websocket_service = websocket_service
         self.agent = None
         self.is_running = False
         self.thread = None
-        self.decision_interval_sec = 15  # Run decision cycle every 15 seconds
+        self.decision_interval_sec = 15
+
+        # For handling HITL requests
+        self._human_decision_events: Dict[str, threading.Event] = {}
+        self._human_decisions: Dict[str, Any] = {}
+        self._lock = threading.Lock()
 
     def load_agent(self, agent_path: str):
         """
         Loads and initializes a central agent from a (simulated) deployment package.
         """
-        # In a real scenario, this would involve parsing the .agent file.
-        # For Phase 2, we'll just instantiate our mock agent.
         logging.info(f"Simulating loading agent from: {agent_path}")
         self.agent = MockManagementAgent()
         logging.info("MockManagementAgent loaded successfully.")
 
+    def _handle_hitl_request(self, action: Dict[str, Any]):
+        """Handles the logic for a Human-in-the-Loop request."""
+        request_id = action.get("request_id")
+        if not request_id:
+            logging.error("HITL action is missing a 'request_id'.")
+            return
+
+        # Prepare for receiving a response
+        event = threading.Event()
+        with self._lock:
+            self._human_decision_events[request_id] = event
+            self._human_decisions.pop(request_id, None) # Clear any old decision
+
+        # Send request to HMI via WebSocket
+        if self.websocket_service:
+            logging.info(f"Requesting human decision for request_id: {request_id}")
+            self.websocket_service.emit('decision_request', action)
+        else:
+            logging.error("WebSocket service is not available for HITL request.")
+            return
+
+        # Wait for the human response
+        timeout_sec = 60.0
+        logging.info(f"Waiting for human response for {timeout_sec} seconds...")
+        event_was_set = event.wait(timeout=timeout_sec)
+
+        with self._lock:
+            decision = self._human_decisions.pop(request_id, None)
+            self._human_decision_events.pop(request_id, None)
+
+        if event_was_set and decision:
+            logging.info(f"Human responded for request {request_id}: {decision}")
+            if decision.get("approved"):
+                # Human approved, publish the command
+                device_id = action.get("target_device_id")
+                command = action.get("proposed_command")
+                self.mqtt_service.publish_command(device_id, command)
+            else:
+                logging.info(f"Human rejected the proposal for request {request_id}.")
+        else:
+            logging.warning(f"HITL request {request_id} timed out. No action taken.")
+
+    def submit_human_decision(self, request_id: str, decision: Dict[str, Any]):
+        """Callback for the WebSocket service to submit a human's decision."""
+        with self._lock:
+            event = self._human_decision_events.get(request_id)
+            if event:
+                self._human_decisions[request_id] = decision
+                event.set() # Signal that the decision has been made
+                logging.info(f"Human decision for {request_id} received and event set.")
+            else:
+                logging.warning(f"Received decision for an unknown or expired request_id: {request_id}")
+
+
     def run_decision_cycle(self):
-        """
-        The main loop for the dispatch engine.
-        """
+        """The main loop for the dispatch engine."""
         while self.is_running:
             logging.info("Starting new decision cycle...")
-
-            # 1. Get system state (observation)
             observation = self.timeseries_db.get_latest_statuses()
+
             if not observation:
                 logging.warning("Observation is empty. Skipping decision cycle.")
                 time.sleep(self.decision_interval_sec)
                 continue
 
-            # 2. Execute agent logic
             if not self.agent:
                 logging.error("No agent loaded. Cannot execute decision cycle.")
                 time.sleep(self.decision_interval_sec)
@@ -70,44 +142,41 @@ class CentralExecutor:
 
             action = self.agent.execute(observation)
 
-            # 3. Process agent's action
             if action:
                 logging.info(f"Agent proposed an action: {action}")
-                if action.get("action_type") == "command":
+                action_type = action.get("action_type")
+
+                if action_type == "command":
                     device_id = action.get("target_device_id")
                     command = action.get("command")
                     if device_id and command:
                         self.mqtt_service.publish_command(device_id, command)
-                # Future: Could have an 'human_in_the_loop' action_type
-                # that would use self.websocket_service
+                elif action_type == "human_in_the_loop":
+                    # Run HITL in a separate thread to not block the main decision cycle
+                    hitl_thread = threading.Thread(target=self._handle_hitl_request, args=(action,))
+                    hitl_thread.start()
+                else:
+                    logging.warning(f"Unknown action type: {action_type}")
             else:
                 logging.info("No action was proposed by the agent in this cycle.")
 
-            # Wait for the next cycle
             time.sleep(self.decision_interval_sec)
 
     def start(self):
-        """
-        Starts the dispatch engine's decision cycle in a background thread.
-        """
+        """Starts the dispatch engine's decision cycle in a background thread."""
         if self.is_running:
             logging.warning("Dispatch engine is already running.")
             return
-
-        # For now, we simulate loading a default agent on start
         self.load_agent("chs-sdk/dist/ManagementAgent.agent")
-
         self.is_running = True
         self.thread = threading.Thread(target=self.run_decision_cycle, daemon=True)
         self.thread.start()
         logging.info("Central Dispatch Engine started.")
 
     def stop(self):
-        """
-        Stops the dispatch engine.
-        """
+        """Stops the dispatch engine."""
         if self.is_running:
             self.is_running = False
             if self.thread:
-                self.thread.join() # Wait for the thread to finish
+                self.thread.join()
             logging.info("Central Dispatch Engine stopped.")

--- a/chs-scada-dispatch/tests/test_central_agent_executor.py
+++ b/chs-scada-dispatch/tests/test_central_agent_executor.py
@@ -1,0 +1,104 @@
+import unittest
+import time
+import threading
+from unittest.mock import Mock, MagicMock, call
+
+from dispatch_engine.central_agent_executor import CentralExecutor
+
+class TestCentralAgentExecutorHITL(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test environment before each test."""
+        self.mock_timeseries_db = Mock()
+        self.mock_mqtt_service = Mock()
+        self.mock_socketio = MagicMock()
+
+        self.executor = CentralExecutor(
+            timeseries_db=self.mock_timeseries_db,
+            mqtt_service=self.mock_mqtt_service,
+            websocket_service=self.mock_socketio
+        )
+        # Lower the interval for faster testing
+        self.executor.decision_interval_sec = 0.1
+        self.executor.load_agent("dummy/path")
+
+    def test_hitl_approve_and_reject_flow(self):
+        """Test both HITL approve and reject flows."""
+        # --- Test Data ---
+        hitl_observation = {
+            "pump_station_01": {
+                "values": {"pressure_psi": 115},
+                "timestamp": "2023-10-27T10:00:00Z"
+            }
+        }
+        no_action_observation = {"pump_station_01": {"values": {"pressure_psi": 100}}}
+
+        # --- Mock setup ---
+        # The first time it's called, it returns data that triggers HITL.
+        # The second time, it returns normal data to allow the loop to continue.
+        self.mock_timeseries_db.get_latest_statuses.side_effect = [
+            hitl_observation,
+            no_action_observation,
+            hitl_observation,
+            no_action_observation
+        ]
+
+        # --- Events for synchronization ---
+        request_emitted_event = threading.Event()
+
+        # We need to capture the arguments passed to emit
+        hitl_request_args = {}
+        def capture_emit(*args, **kwargs):
+            if args[0] == 'decision_request':
+                hitl_request_args['event_name'] = args[0]
+                hitl_request_args['data'] = args[1]
+                request_emitted_event.set()
+
+        self.mock_socketio.emit.side_effect = capture_emit
+
+        # --- Start executor in background thread ---
+        self.executor.start()
+
+        # --- TEST 1: APPROVE ---
+        # Wait for the decision_request to be emitted
+        was_emitted = request_emitted_event.wait(timeout=2)
+        self.assertTrue(was_emitted, "HITL request was not emitted")
+
+        # Get request_id and submit approval
+        request_id = hitl_request_args['data']['request_id']
+        self.executor.submit_human_decision(request_id, {"approved": True})
+
+        # Give executor time to process the approval and publish
+        time.sleep(0.2)
+
+        # Assert MQTT publish was called correctly
+        self.mock_mqtt_service.publish_command.assert_called_once_with(
+            'pump_station_01', {'set_pump_speed': 0.9}
+        )
+
+        # --- Reset for next test ---
+        self.mock_mqtt_service.reset_mock()
+        request_emitted_event.clear()
+        hitl_request_args.clear()
+
+        # --- TEST 2: REJECT ---
+        # Wait for the next decision_request
+        was_emitted = request_emitted_event.wait(timeout=2)
+        self.assertTrue(was_emitted, "Second HITL request was not emitted")
+
+        # Get request_id and submit rejection
+        request_id = hitl_request_args['data']['request_id']
+        self.executor.submit_human_decision(request_id, {"approved": False})
+
+        # Give executor time to process
+        time.sleep(0.2)
+
+        # Assert MQTT publish was NOT called
+        self.mock_mqtt_service.publish_command.assert_not_called()
+
+    def tearDown(self):
+        """Clean up after each test."""
+        self.executor.stop()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit upgrades the CHS-SCADA-Dispatch service to Phase 2, introducing an intelligent dispatch engine and Human-in-the-Loop (HITL) capabilities.

Key changes:
- `dispatch_engine`: Implemented the `CentralExecutor` to load a mock agent, run a decision cycle, and issue commands. Added a full-featured HITL flow using WebSockets, allowing the agent to request human confirmation for moderately high-pressure situations. The executor now handles waiting for the response and acting accordingly.
- `api/websocket_api`: Enhanced the WebSocket service to act as a bridge between the `CentralExecutor` and the HMI. It now receives decision responses from the HMI and passes them to the engine.
- `app.py`: Updated the main application to correctly initialize and wire together the dispatch engine and the WebSocket service, handling the circular dependency.
- `data_processing/timeseries_db`: Verified the existing InfluxDB implementation meets requirements for writing and querying time-series data.
- `data_ingestion/mqtt_service`: Verified the existing MQTT service can publish commands to edge nodes.
- Added unit tests for the new HITL logic in `central_agent_executor` to ensure both "approve" and "reject" scenarios work as expected.