### PR TITLE
Feat: Implement Phase 3 Alarms, History, and Events

### DIFF
--- a/chs-scada-dispatch/.env
+++ b/chs-scada-dispatch/.env
@@ -2,3 +2,4 @@ INFLUXDB_URL=http://127.0.0.1:8086
 INFLUXDB_TOKEN=my-super-secret-token
 INFLUXDB_ORG=my-org
 INFLUXDB_BUCKET=chs_scada_bucket
+INFLUXDB_EVENTS_BUCKET=chs_scada_events_bucket

--- a/chs-scada-dispatch/alarm_engine/engine.py
+++ b/chs-scada-dispatch/alarm_engine/engine.py
@@ -1,0 +1,140 @@
+import logging
+import time
+import threading
+import yaml
+import os
+from fnmatch import fnmatch
+from datetime import datetime
+from typing import List, Dict, Any
+
+from data_processing.timeseries_db import TimeSeriesDB
+from data_processing.event_store import EventStore
+
+
+class AlarmEngine:
+    """
+    Periodically checks device statuses against a set of rules and generates alarms.
+    """
+
+    def __init__(self, timeseries_db: TimeSeriesDB, event_store: EventStore):
+        self.timeseries_db = timeseries_db
+        self.event_store = event_store
+        self.rules = self._load_rules()
+        self.is_running = False
+        self.thread = None
+        self.check_interval_sec = 10
+        # Keep track of active alarms to avoid spamming
+        # Key: (rule_name, device_id), Value: last alarm timestamp
+        self._active_alarms = {}
+
+    def _load_rules(self) -> List[Dict[str, Any]]:
+        """Loads alarm rules from the YAML file."""
+        # Correct path relative to the project root
+        rules_path = os.path.join(os.path.dirname(__file__), 'rules.yaml')
+        try:
+            with open(rules_path, 'r', encoding='utf-8') as f:
+                rules = yaml.safe_load(f)
+                logging.info(f"Successfully loaded {len(rules)} alarm rules from {rules_path}")
+                return rules
+        except FileNotFoundError:
+            logging.error(f"Alarm rules file not found at {rules_path}. No alarms will be generated.")
+            return []
+        except Exception as e:
+            logging.error(f"Error loading or parsing alarm rules: {e}")
+            return []
+
+    def _evaluate_condition(self, condition: str, device_status: Dict[str, Any]) -> bool:
+        """
+        Safely evaluates a rule's condition string against a device's status.
+        'values' is a dictionary available in the local scope of the evaluation.
+        """
+        try:
+            # The 'values' dict from the device status is made available to the eval context
+            return eval(condition, {"__builtins__": {}}, {"values": device_status.get("values", {})})
+        except Exception as e:
+            logging.error(f"Error evaluating condition '{condition}': {e}", exc_info=False)
+            return False
+
+    def run_check_cycle(self):
+        """The main loop for the alarm engine."""
+        while self.is_running:
+            logging.info("Running alarm check cycle...")
+            try:
+                device_statuses = self.timeseries_db.get_latest_statuses()
+                if not device_statuses:
+                    logging.warning("No device statuses received from DB. Skipping alarm check.")
+                else:
+                    self._check_all_devices(device_statuses)
+            except Exception as e:
+                logging.error(f"An unexpected error occurred in the alarm check cycle: {e}", exc_info=True)
+
+            time.sleep(self.check_interval_sec)
+
+    def _check_all_devices(self, device_statuses: Dict[str, Dict[str, Any]]):
+        """Iterates through all devices and their statuses, checking against rules."""
+        for device_id, status in device_statuses.items():
+            for rule in self.rules:
+                # Check if the rule applies to this device using glob-style matching
+                if fnmatch(device_id, rule['device_id_pattern']):
+                    self._check_rule_for_device(rule, device_id, status)
+
+    def _check_rule_for_device(self, rule: Dict[str, Any], device_id: str, status: Dict[str, Any]):
+        """Checks a single rule for a single device and creates an alarm if triggered."""
+        alarm_key = (rule['rule_name'], device_id)
+        is_triggered = self._evaluate_condition(rule['condition'], status)
+
+        if is_triggered:
+            # Prevent re-triggering an alarm that is already active
+            if alarm_key in self._active_alarms:
+                logging.debug(f"Alarm {alarm_key} is already active. Skipping.")
+                return
+
+            logging.warning(f"ALARM TRIGGERED: Rule '{rule['rule_name']}' for device '{device_id}'")
+            self._active_alarms[alarm_key] = datetime.utcnow()
+
+            # Format the message with device-specific values
+            message = rule['message'].format(device_id=device_id, values=status.get("values", {}))
+
+            alarm_event = {
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "type": "ALARM",
+                "severity": rule['severity'],
+                "source": device_id,
+                "message": message,
+                "status": "ACTIVE",
+                "rule_name": rule['rule_name']
+            }
+            # This will be implemented in the next step
+            if self.event_store:
+                self.event_store.add_event(alarm_event)
+
+        else:
+            # If the condition is no longer met, the alarm can be considered resolved
+            if alarm_key in self._active_alarms:
+                logging.info(f"ALARM RESOLVED: Rule '{rule['rule_name']}' for device '{device_id}'")
+                # Here you could update the event status to 'RESOLVED'
+                # For now, we just remove it from the active list to allow re-triggering
+                del self._active_alarms[alarm_key]
+
+
+    def start(self):
+        """Starts the alarm engine's check cycle in a background thread."""
+        if self.is_running:
+            logging.warning("Alarm engine is already running.")
+            return
+        if not self.rules:
+            logging.warning("No rules loaded. Alarm engine will not start.")
+            return
+
+        self.is_running = True
+        self.thread = threading.Thread(target=self.run_check_cycle, daemon=True)
+        self.thread.start()
+        logging.info("Alarm Engine started.")
+
+    def stop(self):
+        """Stops the alarm engine."""
+        if self.is_running:
+            self.is_running = False
+            if self.thread:
+                self.thread.join()
+            logging.info("Alarm Engine stopped.")

--- a/chs-scada-dispatch/alarm_engine/rules.yaml
+++ b/chs-scada-dispatch/alarm_engine/rules.yaml
@@ -1,0 +1,11 @@
+- rule_name: "Reservoir High Level Warning"
+  device_id_pattern: "res_*" # 适用于所有水库
+  condition: "values.level > 150.0"
+  severity: "WARNING"
+  message: "水库 {device_id} 水位 {values.level:.2f}m 已超过 150.0m 警戒线！"
+
+- rule_name: "Pump Offline Alert"
+  device_id_pattern: "pump_station_*"
+  condition: "values.pump_status == 0"
+  severity: "CRITICAL"
+  message: "泵站 {device_id} 的水泵已离线！"

--- a/chs-scada-dispatch/api/rest_api.py
+++ b/chs-scada-dispatch/api/rest_api.py
@@ -1,9 +1,11 @@
 from flask import Flask, jsonify, request
 from data_processing.timeseries_db import TimeSeriesDB
+from data_processing.event_store import EventStore
 from data_ingestion.mqtt_service import MqttService
 import logging
+from datetime import datetime, timedelta
 
-def create_rest_app(timeseries_db: TimeSeriesDB, mqtt_service: MqttService):
+def create_rest_app(timeseries_db: TimeSeriesDB, event_store: EventStore, mqtt_service: MqttService):
     """
     Creates and configures the Flask application for RESTful APIs.
     Injects dependencies to make the app modular and testable.
@@ -45,6 +47,57 @@ def create_rest_app(timeseries_db: TimeSeriesDB, mqtt_service: MqttService):
             return jsonify({"message": "Command successfully sent to the queue."}), 202
         except Exception as e:
             logging.error(f"Error in /api/v1/command: {e}", exc_info=True)
+            return jsonify({"error": "An internal server error occurred"}), 500
+
+    @app.route('/api/v1/events', methods=['GET'])
+    def get_events():
+        """
+        API endpoint to get the list of alarms and system events.
+        """
+        try:
+            # Get query parameters
+            filter_status = request.args.get('filter', default='all', type=str)
+            limit = request.args.get('limit', default=100, type=int)
+
+            events = event_store.get_events(filter_status=filter_status, limit=limit)
+            logging.info(f"API call to /api/v1/events with filter='{filter_status}' returned {len(events)} events.")
+            return jsonify(events)
+        except Exception as e:
+            logging.error(f"Error in /api/v1/events: {e}", exc_info=True)
+            return jsonify({"error": "An internal server error occurred"}), 500
+
+    @app.route('/api/v1/devices/<string:device_id>/history', methods=['GET'])
+    def get_device_history(device_id):
+        """
+        API endpoint to get historical data for a specific device.
+        """
+        try:
+            # Get and parse query parameters
+            time_range_str = request.args.get('range', default='1h', type=str)
+
+            # Simple parser for range string like '1h', '24h', '7d'
+            # Note: In a real production system, this would be more robust.
+            if time_range_str.endswith('h'):
+                hours = int(time_range_str[:-1])
+                delta = timedelta(hours=hours)
+            elif time_range_str.endswith('d'):
+                days = int(time_range_str[:-1])
+                delta = timedelta(days=days)
+            else: # Default to 1 hour if format is unrecognized
+                delta = timedelta(hours=1)
+
+            # The `get_historical_status` method expects a relative time string (e.g., "-1h")
+            # or an absolute timestamp. We can simplify this by passing the relative time string directly.
+            # The 'end' parameter is optional in the DB layer method.
+
+            # The field parameter is not used yet, but could be in the future
+            # field = request.args.get('field', type=str)
+
+            history = timeseries_db.get_historical_status(device_id, start=f"-{time_range_str}", end="now()")
+            logging.info(f"API call to /api/v1/devices/{device_id}/history with range='{time_range_str}' returned {len(history)} points.")
+            return jsonify(history)
+        except Exception as e:
+            logging.error(f"Error in /api/v1/devices/{device_id}/history: {e}", exc_info=True)
             return jsonify({"error": "An internal server error occurred"}), 500
 
     return app

--- a/chs-scada-dispatch/data_processing/event_store.py
+++ b/chs-scada-dispatch/data_processing/event_store.py
@@ -1,0 +1,105 @@
+import os
+import logging
+from datetime import datetime
+from influxdb_client import InfluxDBClient, Point, WriteOptions
+from influxdb_client.client.write_api import SYNCHRONOUS
+from typing import List, Dict, Any, Optional
+
+class EventStore:
+    """
+    Manages the storage and retrieval of alarm and system events in InfluxDB.
+    """
+    def __init__(self):
+        """
+        Initializes the InfluxDB client for the events bucket.
+        """
+        self.url = os.getenv("INFLUXDB_URL")
+        self.token = os.getenv("INFLUXDB_TOKEN")
+        self.org = os.getenv("INFLUXDB_ORG")
+        # Use a separate bucket for events, defined in the environment
+        self.bucket = os.getenv("INFLUXDB_EVENTS_BUCKET", "scada-events") # Default value for safety
+
+        if not all([self.url, self.token, self.org, self.bucket]):
+            raise ValueError("InfluxDB credentials (URL, TOKEN, ORG, EVENTS_BUCKET) not set in environment variables.")
+
+        try:
+            self.client = InfluxDBClient(url=self.url, token=self.token, org=self.org)
+            self.write_api = self.client.write_api(write_options=SYNCHRONOUS)
+            self.query_api = self.client.query_api()
+            logging.info(f"Successfully connected to InfluxDB for EventStore at {self.url} (bucket: {self.bucket})")
+        except Exception as e:
+            logging.error(f"Failed to connect to InfluxDB for EventStore: {e}")
+            raise
+
+    def add_event(self, event_data: Dict[str, Any]):
+        """
+        Writes an event (alarm or system event) to the InfluxDB events bucket.
+        """
+        try:
+            timestamp = event_data.get("timestamp", datetime.utcnow().isoformat() + "Z")
+
+            point = Point("event") \
+                .time(timestamp) \
+                .tag("type", event_data.get("type")) \
+                .tag("source", event_data.get("source")) \
+                .tag("severity", event_data.get("severity")) \
+                .tag("status", event_data.get("status")) \
+                .field("message", event_data.get("message", "")) \
+                .field("rule_name", event_data.get("rule_name", "")) # Add other relevant fields
+
+            self.write_api.write(bucket=self.bucket, org=self.org, record=point)
+            logging.info(f"Successfully wrote event from source {event_data.get('source')} to event store.")
+        except Exception as e:
+            logging.error(f"Error writing event to InfluxDB: {e}")
+
+    def get_events(self, filter_status: Optional[str] = None, limit: int = 100) -> List[Dict[str, Any]]:
+        """
+        Retrieves a list of events, with optional filtering by status.
+        """
+        events = []
+        try:
+            # Base query
+            flux_query = f'''
+            from(bucket: "{self.bucket}")
+              |> range(start: -30d) // Look back 30 days, adjust as needed
+              |> filter(fn: (r) => r["_measurement"] == "event")
+            '''
+
+            # Add filter if provided
+            if filter_status and filter_status.lower() != 'all':
+                flux_query += f' |> filter(fn: (r) => r["status"] == "{filter_status.upper()}")'
+
+            # Add sorting and limit
+            flux_query += f'''
+              |> sort(columns: ["_time"], desc: true)
+              |> limit(n: {limit})
+              |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+            '''
+
+            tables = self.query_api.query(flux_query, org=self.org)
+
+            for table in tables:
+                for record in table.records:
+                    event_record = {
+                        "timestamp": record.get_time().isoformat(),
+                        "type": record.values.get('type'),
+                        "source": record.values.get('source'),
+                        "severity": record.values.get('severity'),
+                        "status": record.values.get('status'),
+                        "message": record.values.get('message'),
+                        "rule_name": record.values.get('rule_name')
+                    }
+                    events.append(event_record)
+
+            logging.info(f"Retrieved {len(events)} events from the event store.")
+            return events
+        except Exception as e:
+            logging.error(f"Error querying events from InfluxDB: {e}")
+            return []
+
+    def close(self):
+        """
+        Closes the InfluxDB client connection.
+        """
+        self.client.close()
+        logging.info("EventStore InfluxDB client closed.")

--- a/chs-scada-dispatch/requirements.txt
+++ b/chs-scada-dispatch/requirements.txt
@@ -3,3 +3,4 @@ paho-mqtt
 influxdb-client[ciso]
 flask-socketio
 python-dotenv
+PyYAML


### PR DESCRIPTION
This commit introduces the features for Phase 3 of the CHS-SCADA-Dispatch project, turning it into a production-grade monitoring platform.

Key additions include:
- **Alarm Engine:** A new `alarm_engine` service that periodically checks device statuses against user-defined rules in `rules.yaml`. It generates structured alarm events when conditions are met.
- **Event Store:** A new `EventStore` service in the `data_processing` layer to store and retrieve alarm and system events from a dedicated InfluxDB bucket.
- **API Enhancements:** The REST API is upgraded with two new endpoints:
  - `GET /api/v1/events`: To retrieve a list of alarms and events.
  - `GET /api/v1/devices/{device_id}/history`: To query historical time-series data for a specific device.
- **Integration:** All new services are integrated into the main application lifecycle, ensuring they start and stop gracefully.