### PR TITLE
feat: Integrate AI Agent Training Workflow

### DIFF
--- a/chs-hmi/src/components/TrainingModal.js
+++ b/chs-hmi/src/components/TrainingModal.js
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import { trainAgent } from '../services/apiService';
+
+const TrainingModal = ({ project, onClose, onTrainingStarted }) => {
+    const [algorithm, setAlgorithm] = useState('PPO');
+    const [totalTimesteps, setTotalTimesteps] = useState(10000);
+    const [isTraining, setIsTraining] = useState(false);
+    const [error, setError] = useState('');
+
+    const handleTrain = async (e) => {
+        e.preventDefault();
+        setError('');
+        setIsTraining(true);
+
+        const params = {
+            algorithm,
+            total_timesteps: parseInt(totalTimesteps, 10),
+        };
+
+        try {
+            const result = await trainAgent(project.id, params);
+            alert(`Training started successfully! Model ID: ${result.model.id}`);
+            onTrainingStarted();
+            onClose();
+        } catch (err) {
+            setError(err.message);
+            alert(`Training failed: ${err.message}`);
+        } finally {
+            setIsTraining(false);
+        }
+    };
+
+    // Basic modal styles
+    const modalStyle = {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        backgroundColor: 'rgba(0, 0, 0, 0.5)',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+    };
+
+    const modalContentStyle = {
+        backgroundColor: 'white',
+        padding: '20px 40px',
+        borderRadius: '5px',
+        width: '400px',
+    };
+
+    const inputGroupStyle = {
+        marginBottom: '15px',
+    };
+
+    const labelStyle = {
+        display: 'block',
+        marginBottom: '5px',
+    };
+
+    const inputStyle = {
+        width: '100%',
+        padding: '8px',
+        boxSizing: 'border-box',
+    };
+
+    const buttonStyle = {
+        padding: '10px 20px',
+        border: 'none',
+        borderRadius: '3px',
+        cursor: 'pointer',
+    };
+
+    const primaryBtnStyle = { ...buttonStyle, backgroundColor: '#007bff', color: 'white' };
+    const secondaryBtnStyle = { ...buttonStyle, backgroundColor: '#6c757d', color: 'white', marginRight: '10px' };
+
+
+    return (
+        <div style={modalStyle} onClick={onClose}>
+            <div style={modalContentStyle} onClick={e => e.stopPropagation()}>
+                <h2>Train Agent for {project.name}</h2>
+                <form onSubmit={handleTrain}>
+                    <div style={inputGroupStyle}>
+                        <label style={labelStyle}>Algorithm</label>
+                        <select
+                            style={inputStyle}
+                            value={algorithm}
+                            onChange={(e) => setAlgorithm(e.target.value)}
+                        >
+                            <option value="PPO">PPO</option>
+                            {/* Add other algorithms here in the future */}
+                        </select>
+                    </div>
+                    <div style={inputGroupStyle}>
+                        <label style={labelStyle}>Total Timesteps</label>
+                        <input
+                            style={inputStyle}
+                            type="number"
+                            value={totalTimesteps}
+                            onChange={(e) => setTotalTimesteps(e.target.value)}
+                        />
+                    </div>
+                    {error && <p style={{ color: 'red' }}>{error}</p>}
+                    <div>
+                        <button type="button" onClick={onClose} style={secondaryBtnStyle} disabled={isTraining}>
+                            Cancel
+                        </button>
+                        <button type="submit" style={primaryBtnStyle} disabled={isTraining}>
+                            {isTraining ? 'Training...' : 'Start Training'}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default TrainingModal;

--- a/chs-hmi/src/services/apiService.js
+++ b/chs-hmi/src/services/apiService.js
@@ -126,3 +126,46 @@ export const updateDeviceConfig = async (deviceId, config) => {
   // await axios.post(`/api/v1/devices/${deviceId}/config`, config);
   return Promise.resolve({ success: true, message: `Device ${deviceId} configuration updated.` });
 };
+
+/**
+ * Starts a training job for a project.
+ * @param {string} projectId - The ID of the project.
+ * @param {object} params - The training parameters (e.g., { algorithm: 'PPO', total_timesteps: 100000 }).
+ * @returns {Promise<Object>} A promise that resolves to the new model data.
+ */
+export const trainAgent = async (projectId, params) => {
+  try {
+    const response = await axios.post(`/api/projects/${projectId}/train`, params);
+    return response.data;
+  } catch (error) {
+    console.error(`Error starting training for project ${projectId}:`, error);
+    if (error.response) {
+      throw new Error(`Backend error: ${error.response.status} ${error.response.data.message || ''}`);
+    } else if (error.request) {
+      throw new Error('Could not connect to the server.');
+    } else {
+      throw new Error(`An unexpected error occurred: ${error.message}`);
+    }
+  }
+};
+
+/**
+ * Fetches the list of trained models for a project.
+ * @param {string} projectId - The ID of the project.
+ * @returns {Promise<Array>} A promise that resolves to an array of model objects.
+ */
+export const fetchProjectModels = async (projectId) => {
+  try {
+    const response = await axios.get(`/api/projects/${projectId}/models`);
+    return response.data;
+  } catch (error) {
+    console.error(`Error fetching models for project ${projectId}:`, error);
+    if (error.response) {
+      throw new Error(`Backend error: ${error.response.status} ${error.response.data.message || ''}`);
+    } else if (error.request) {
+      throw new Error('Could not connect to the server.');
+    } else {
+      throw new Error(`An unexpected error occurred: ${error.message}`);
+    }
+  }
+};

--- a/chs-hmi/src/views/Dashboard.js
+++ b/chs-hmi/src/views/Dashboard.js
@@ -1,77 +1,80 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
+import { fetchProjectModels } from '../services/apiService';
+import TrainingModal from '../components/TrainingModal';
 
 const Dashboard = () => {
     const [projects, setProjects] = useState([]);
     const [error, setError] = useState('');
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedProject, setSelectedProject] = useState(null);
 
-    useEffect(() => {
-        const fetchProjects = async () => {
-            try {
-                const response = await axios.get('/api/projects');
-                setProjects(response.data);
-            } catch (err) {
-                setError('Failed to fetch projects. Is the backend running?');
-                console.error(err);
-            }
-        };
-        fetchProjects();
+    const fetchProjectsAndModels = useCallback(async () => {
+        try {
+            const projectsResponse = await axios.get('/api/projects');
+            const projectsData = projectsResponse.data;
+
+            const projectsWithModels = await Promise.all(
+                projectsData.map(async (project) => {
+                    try {
+                        const models = await fetchProjectModels(project.id);
+                        return { ...project, models: models || [] };
+                    } catch (modelError) {
+                        console.error(`Failed to fetch models for project ${project.id}`, modelError);
+                        return { ...project, models: [] }; // Return project without models on error
+                    }
+                })
+            );
+
+            setProjects(projectsWithModels);
+        } catch (err) {
+            setError('Failed to fetch projects. Is the backend running?');
+            console.error(err);
+        }
     }, []);
 
-    const containerStyle = {
-        fontFamily: 'sans-serif',
-        padding: '20px',
-        maxWidth: '800px',
-        margin: '0 auto',
+    useEffect(() => {
+        fetchProjectsAndModels();
+    }, [fetchProjectsAndModels]);
+
+    const handleOpenTrainModal = (project) => {
+        setSelectedProject(project);
+        setIsModalOpen(true);
     };
 
-    const headerStyle = {
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
-        borderBottom: '2px solid #eee',
-        paddingBottom: '10px',
-        marginBottom: '20px',
+    const handleCloseModal = () => {
+        setIsModalOpen(false);
+        setSelectedProject(null);
     };
 
-    const projectCardStyle = {
-        border: '1px solid #ddd',
-        borderRadius: '5px',
-        padding: '15px',
-        marginBottom: '15px',
-        display: 'flex',
-        justifyContent: 'space-between',
-        alignItems: 'center',
+    const handleTrainingComplete = () => {
+        // Refresh the data after training is done
+        fetchProjectsAndModels();
     };
-
-    const buttonStyle = {
-        padding: '8px 15px',
-        margin: '0 5px',
-        border: 'none',
-        borderRadius: '3px',
-        cursor: 'pointer',
-        textDecoration: 'none',
-        color: 'white',
-    };
-
-    const createBtnStyle = { ...buttonStyle, backgroundColor: '#28a745' };
-    const viewBtnStyle = { ...buttonStyle, backgroundColor: '#007bff' };
-    const editBtnStyle = { ...buttonStyle, backgroundColor: '#ffc107', color: 'black' };
-    const runBtnStyle = { ...buttonStyle, backgroundColor: '#17a2b8' };
 
     const handleRun = async (projectId) => {
         try {
             alert(`Running simulation for project ${projectId}...`);
             await axios.post(`/api/projects/${projectId}/run`);
             alert(`Simulation for project ${projectId} completed!`);
-            // Optionally, you could refresh the results or navigate to the results page
         } catch (err) {
             alert(`Failed to run simulation for project ${projectId}.`);
             console.error(err);
         }
     };
 
+    // Styles
+    const containerStyle = { fontFamily: 'sans-serif', padding: '20px', maxWidth: '900px', margin: '0 auto' };
+    const headerStyle = { display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '2px solid #eee', paddingBottom: '10px', marginBottom: '20px' };
+    const projectCardStyle = { border: '1px solid #ddd', borderRadius: '8px', padding: '20px', marginBottom: '20px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' };
+    const buttonStyle = { padding: '8px 15px', border: 'none', borderRadius: '5px', cursor: 'pointer', textDecoration: 'none', color: 'white', display: 'block', width: '100%', boxSizing: 'border-box', textAlign: 'center' };
+    const createBtnStyle = { ...buttonStyle, backgroundColor: '#28a745', display: 'inline-block', width: 'auto' };
+    const viewBtnStyle = { ...buttonStyle, backgroundColor: '#007bff' };
+    const editBtnStyle = { ...buttonStyle, backgroundColor: '#ffc107', color: 'black' };
+    const runBtnStyle = { ...buttonStyle, backgroundColor: '#17a2b8' };
+    const trainBtnStyle = { ...buttonStyle, backgroundColor: '#6f42c1' };
+    const downloadBtnStyle = { ...buttonStyle, backgroundColor: '#20c997', padding: '5px 10px', textDecoration: 'none', display: 'inline-block', width: 'auto' };
 
     return (
         <div style={containerStyle}>
@@ -84,9 +87,30 @@ const Dashboard = () => {
                 {projects.length > 0 ? (
                     projects.map(project => (
                         <div key={project.id} style={projectCardStyle}>
-                            <h3>{project.name}</h3>
-                            <div>
-                                <button onClick={() => handleRun(project.id)} style={runBtnStyle}>Run</button>
+                            <div style={{ flex: 1, marginRight: '20px' }}>
+                                <h3>{project.name}</h3>
+                                <div style={{ marginTop: '15px' }}>
+                                    <h4>Trained Models:</h4>
+                                    {project.models.length > 0 ? (
+                                        <ul style={{ listStyle: 'none', paddingLeft: 0 }}>
+                                            {project.models.map(model => (
+                                                <li key={model.id} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '8px 0', borderBottom: '1px solid #eee' }}>
+                                                    <div>
+                                                        <div><strong>Algorithm:</strong> {model.algorithm}</div>
+                                                        <div style={{fontSize: '0.8em', color: '#666'}}><strong>Trained at:</strong> {new Date(model.created_at).toLocaleString()}</div>
+                                                    </div>
+                                                    <a href={`/api/models/${model.id}`} style={downloadBtnStyle} download>Download</a>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    ) : (
+                                        <p>No models trained yet.</p>
+                                    )}
+                                </div>
+                            </div>
+                            <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', width: '150px' }}>
+                                <button onClick={() => handleOpenTrainModal(project)} style={trainBtnStyle}>Train Agent</button>
+                                <button onClick={() => handleRun(project.id)} style={runBtnStyle}>Run Sim</button>
                                 <Link to={`/project/${project.id}/results`} style={viewBtnStyle}>View Results</Link>
                                 <Link to={`/project/${project.id}/edit`} style={editBtnStyle}>Edit</Link>
                             </div>
@@ -96,6 +120,14 @@ const Dashboard = () => {
                     !error && <p>No projects found. Create one to get started!</p>
                 )}
             </div>
+
+            {isModalOpen && selectedProject && (
+                <TrainingModal
+                    project={selectedProject}
+                    onClose={handleCloseModal}
+                    onTrainingStarted={handleTrainingComplete}
+                />
+            )}
         </div>
     );
 };

--- a/chs-twin-factory/backend/gym_wrapper.py
+++ b/chs-twin-factory/backend/gym_wrapper.py
@@ -1,0 +1,117 @@
+import gymnasium as gym
+from gymnasium import spaces
+import numpy as np
+import json
+
+# Assuming CHS_SDK can be imported this way.
+# The actual path might need adjustment during integration.
+from water_system_sdk.src.chs_sdk.main import CHS_SDK
+
+
+class ChsEnv(gym.Env):
+    """Custom Environment for CHS-SDK that follows the gymnasium interface."""
+    metadata = {'render_modes': ['human']}
+
+    def __init__(self, scenario_json: str):
+        super().__init__()
+
+        self.scenario_config = json.loads(scenario_json)
+        self.sdk = CHS_SDK(self.scenario_config)
+
+        # --- Define action and observation space ---
+        # The spaces are defined dynamically based on the scenario config.
+        # This is a simplified example assuming specific keys in the config.
+
+        # Example Action Space: Control the outflow of the first controllable component.
+        # In a real implementation, you would parse config['control']
+        action_low = np.array([0.0], dtype=np.float32)
+        action_high = np.array([100.0], dtype=np.float32) # Assuming a max_flow of 100
+        self.action_space = spaces.Box(low=action_low, high=action_high, dtype=np.float32)
+
+        # Example Observation Space: Observe the level of the first reservoir.
+        # In a real implementation, you would parse config['components']
+        obs_low = np.array([80.0], dtype=np.float32) # Assuming min_level
+        obs_high = np.array([100.0], dtype=np.float32) # Assuming max_level
+        self.observation_space = spaces.Box(low=obs_low, high=obs_high, dtype=np.float32)
+
+        self.target_level = 95.0 # Example target level for reward
+
+    def _get_obs(self):
+        """Helper function to get the current observation from the SDK."""
+        state = self.sdk.get_current_state()
+        # This is highly dependent on the scenario's component IDs.
+        # This should be made more robust.
+        # Assuming the first component is the reservoir we want to observe.
+        first_component_id = list(state.keys())[0]
+        level = state[first_component_id].get('level', self.target_level)
+        return np.array([level], dtype=np.float32)
+
+    def _get_info(self):
+        """Helper function to get diagnostic information."""
+        return {}
+
+    def reset(self, seed=None, options=None):
+        super().reset(seed=seed)
+
+        # Re-initialize the SDK to reset the simulation state
+        self.sdk = CHS_SDK(self.scenario_config)
+
+        observation = self._get_obs()
+        info = self._get_info()
+
+        return observation, info
+
+    def step(self, action):
+        # --- Map action to SDK's expected format ---
+        # This is also dependent on the scenario config.
+        # Assuming the action controls the outflow of the first controllable component.
+        control_config = self.scenario_config.get('control', [])
+        if not control_config:
+            raise ValueError("No control defined in the scenario config.")
+
+        target_component_id = control_config[0]['component_id']
+        target_variable = control_config[0]['variable']
+
+        sdk_action = {
+            target_component_id: {
+                target_variable: float(action[0])
+            }
+        }
+
+        # --- Run one timestep in the simulation ---
+        self.sdk.run_step(sdk_action)
+
+        # --- Get the new state (observation) ---
+        observation = self._get_obs()
+
+        # --- Calculate reward ---
+        # Reward is higher the closer the level is to the target level.
+        level = observation[0]
+        reward = -np.abs(level - self.target_level)
+
+        # --- Check for termination ---
+        # For simplicity, we don't terminate the episode here.
+        # In a real scenario, this could be based on reaching a critical level.
+        terminated = False
+        truncated = False # For when the episode is ended by a time limit
+
+        info = self._get_info()
+
+        return observation, reward, terminated, truncated, info
+
+    def render(self, mode='human'):
+        # For now, we'll just print the current state
+        if mode == 'human':
+            obs = self._get_obs()
+            print(f"Current Level: {obs[0]}")
+
+    def close(self):
+        pass
+
+
+def create_chs_env(scenario_json: str) -> gym.Env:
+    """
+    Factory function to create an instance of the ChsEnv.
+    """
+    env = ChsEnv(scenario_json)
+    return env

--- a/chs-twin-factory/backend/requirements.txt
+++ b/chs-twin-factory/backend/requirements.txt
@@ -3,4 +3,6 @@ Flask-SQLAlchemy
 Flask-Migrate
 loguru
 pydantic
+stable-baselines3
+gymnasium
 -e ../../water_system_sdk

--- a/test_phase4_workflow.py
+++ b/test_phase4_workflow.py
@@ -1,0 +1,116 @@
+import requests
+import json
+import time
+import subprocess
+import os
+import sys
+
+# --- 1. Start the backend server ---
+print("Starting backend server...")
+python_executable = sys.executable
+# Running app.py from its directory is safer for relative paths
+server_process = subprocess.Popen(
+    [python_executable, 'app.py'],
+    cwd='chs-twin-factory/backend/',
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True
+)
+# Give the server time to start up and initialize the database
+time.sleep(10)
+
+BASE_URL = 'http://127.0.0.1:5001'
+model_filename = None
+
+try:
+    # --- 2. Create a project ---
+    print("Creating a new project...")
+    # This scenario is for the new CHS_SDK used by the gym_wrapper
+    scenario = {
+        "components": [
+            {
+                "id": "R1", "type": "Reservoir",
+                "params": { "initial_level": 90, "max_level": 100, "min_level": 80, "area": 1000 }
+            },
+            {
+                "id": "T1", "type": "Turbine",
+                "params": { "max_flow": 100 }
+            }
+        ],
+        "connections": [
+            {"from": "R1", "to": "T1"}
+        ],
+        "control": [
+            { "component_id": "T1", "variable": "outflow" }
+        ]
+    }
+    project_data = {
+        "name": "Test RL Project",
+        "scenario": scenario
+    }
+    response = requests.post(f"{BASE_URL}/api/projects", json=project_data)
+    response.raise_for_status()
+    project = response.json()['project']
+    project_id = project['id']
+    print(f"Project created with ID: {project_id}")
+
+    # --- 3. Start training ---
+    print("Starting training... (This may take a minute or two)")
+    train_params = {
+        "algorithm": "PPO",
+        "total_timesteps": 256 # very short, but enough for SB3 to initialize and save
+    }
+    # This is a blocking call and might take a while, so we use a generous timeout
+    response = requests.post(f"{BASE_URL}/api/projects/{project_id}/train", json=train_params, timeout=180)
+    response.raise_for_status()
+    train_result = response.json()
+    print("Training complete:", train_result)
+    assert train_result['status'] == 'success'
+
+    # --- 4. Check for the model ---
+    print("Fetching models for the project...")
+    response = requests.get(f"{BASE_URL}/api/projects/{project_id}/models")
+    response.raise_for_status()
+    models = response.json()
+    print(f"Found models: {models}")
+    assert len(models) > 0
+    model_id = models[0]['id']
+
+    # --- 5. Download the model ---
+    print(f"Downloading model with ID: {model_id}...")
+    response = requests.get(f"{BASE_URL}/api/models/{model_id}", stream=True)
+    response.raise_for_status()
+
+    model_filename = f"test_model_{model_id}.zip"
+    with open(model_filename, 'wb') as f:
+        for chunk in response.iter_content(chunk_size=8192):
+            f.write(chunk)
+
+    print(f"Model saved to {model_filename}")
+    # Check if the file is a non-empty zip file
+    assert os.path.getsize(model_filename) > 100
+
+    print("\n--- Test workflow successful! ---")
+
+except Exception as e:
+    print(f"\n--- Test failed: An unexpected error occurred: {e} ---", file=sys.stderr)
+    # Give a moment for any final output from the server
+    time.sleep(1)
+    # Now terminate and get output
+    server_process.terminate()
+    stdout, stderr = server_process.communicate()
+    print("--- Server STDOUT ---", file=sys.stderr)
+    print(stdout, file=sys.stderr)
+    print("--- Server STDERR ---", file=sys.stderr)
+    print(stderr, file=sys.stderr)
+    sys.exit(1) # Exit with error
+
+finally:
+    # --- 6. Clean up ---
+    print("Stopping backend server...")
+    server_process.terminate()
+    server_process.wait()
+    # Clean up the downloaded file
+    if model_filename and os.path.exists(model_filename):
+        os.remove(model_filename)
+        print(f"Cleaned up {model_filename}")


### PR DESCRIPTION
This commit introduces the Phase 4 features for CHS-Twin-Factory, transforming it into an AI agent training and management platform.

Key changes include:
- **Backend:**
  - Added `stable-baselines3` and `gymnasium` dependencies for RL training.
  - Implemented `gym_wrapper.py` to wrap `chs-sdk` simulations into a standard Gymnasium environment.
  - Upgraded the API with endpoints to train models (`/api/projects/{id}/train`), view trained models (`/api/projects/{id}/models`), and download them (`/api/models/{id}`).
  - Updated the database schema to include a `TrainedModel` table.

- **Frontend:**
  - Created an 'AI Training Panel' as a modal on the project dashboard.
  - Users can select an algorithm (PPO) and configure hyperparameters like total timesteps to launch a training job.
  - Implemented an 'Agent Management' section on the dashboard to display all trained models for a project.
  - Added functionality to download the trained agent models directly from the UI.