### PR TITLE
docs: Generate CHS product documentation

### DIFF
--- a/chs-edge/README.md
+++ b/chs-edge/README.md
@@ -1,7 +1,32 @@
-# CHS-Edge
+# chs-edge - 边缘计算节点
 
-This directory is for the CHS-Edge product.
+*   **角色**: 连接数字与物理世界的“神经末梢”。部署在现场，负责实时数据采集、本地指令执行，并将数据上传至云端。
 
-- `engine/`: Contains the core engine source code.
-- `drivers/`: Contains the device drivers.
-- `services/`: Contains the services that run on the edge device.
+## 详细目录结构与代码解析
+
+```
+chs-edge/
+├── README.md
+├── config.env
+├── create_sample_agent.py
+├── main.py
+├── model.agent
+├── requirements.txt
+├── chs_sdk/
+├── drivers/
+├── engine/
+└── services/
+```
+
+### 代码现状分析
+
+*   这是一个功能完备的、模块化的边缘计算应用。
+*   **main.py**: 应用主入口。
+*   **engine/**: 核心业务逻辑引擎。
+*   **drivers/**: 硬件驱动与连接器。
+*   **services/**: 应用服务模块。
+*   **chs_sdk/**: 本地化的 SDK。
+*   **model.agent**: 示例 Agent 模型。
+*   **create_sample_agent.py**: 辅助工具脚本。
+*   **config.env**: 配置文件。
+*   **requirements.txt**: 依赖项列表。

--- a/chs-hmi/README.md
+++ b/chs-hmi/README.md
@@ -1,70 +1,26 @@
-# Getting Started with Create React App
+# chs-hmi - 人机交互界面
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+*   **角色**: 系统的“眼睛”和“手”。为操作员提供一个直观的监控和干预界面。
 
-## Available Scripts
+## 详细目录结构与代码解析
 
-In the project directory, you can run:
+```
+chs-hmi/
+├── .gitignore
+├── README.md
+├── package-lock.json
+├── package.json
+├── jules-scratch/
+│   └── verification/
+├── public/
+└── src/
+```
 
-### `npm start`
+### 代码现状分析
 
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+*   这是一个标准的 Node.js 前端项目。
+*   **package.json**: 前端项目配置文件。
+*   **package-lock.json**: 依赖版本锁定文件。
+*   **src/**: 应用源代码目录。
+*   **public/**: 静态资源目录。
+*   **jules-scratch/verification/**: 临时或实验性目录。

--- a/chs-knowledge-hub/README.md
+++ b/chs-knowledge-hub/README.md
@@ -1,0 +1,26 @@
+# chs-knowledge-hub - 知识中心
+
+*   **角色**: 项目的“维基百科”与“图书馆”。负责以文档的形式，沉淀和管理项目的设计思想、技术方案、教程和最佳实践。
+
+## 详细目录结构与代码解析
+
+```
+chs-knowledge-hub/
+├── .gitignore
+├── mkdocs.yml
+└── docs/
+    ├── api_reference/
+    ├── assets/
+    ├── case_studies/
+    ├── sdk_tutorials/
+    ├── agent_zoo.md
+    ├── community.md
+    ├── contributing.md
+    └── index.md
+```
+
+### 代码现状分析
+
+*   这是一个使用 MkDocs 工具构建的静态文档网站。
+*   **mkdocs.yml**: 网站配置文件。
+*   **docs/**: 文档源文件目录，包含了 API 参考、案例研究、教程、模型库说明、社区和贡献指南等丰富内容。

--- a/chs-scada-dispatch/README.md
+++ b/chs-scada-dispatch/README.md
@@ -1,8 +1,36 @@
-# CHS-SCADA-Dispatch
+# chs-scada-dispatch - 云端指挥中心
 
-This directory is for the CHS-SCADA-Dispatch product.
+*   **角色**: 业务运行的“云端大脑”。负责接收所有边缘节点的数据，进行集中式的分析决策，并将指令下发给边缘节点执行。
 
-- `data_ingestion/`: For data ingestion components.
-- `data_processing/`: For data processing components.
-- `api/`: For the API that exposes the dispatch functionality.
-- `dispatch_engine/`: For the core dispatch engine.
+## 详细目录结构与代码解析
+
+```
+chs-scada-dispatch/
+├── .env
+├── .env.example
+├── README.md
+├── app.py
+├── requirements.txt
+├── test_publisher.py
+├── alarm_engine/
+├── api/
+├── audit_log/
+├── data_ingestion/
+├── data_processing/
+├── dispatch_engine/
+└── tests/
+```
+
+### 代码现状分析
+
+*   这是一个功能丰富的、模块化的后端服务应用。
+*   **app.py**: Web 应用主入口。使用 Flask 或 FastAPI 框架，负责初始化和启动整个后端服务。
+*   **api/**: API 接口层。包含所有对外暴露的 REST API 端点定义。
+*   **data_ingestion/**: 数据接收模块。负责处理最原始的数据流入。
+*   **data_processing/**: 数据处理与分析模块。进行数据清洗、转换、计算等操作。
+*   **dispatch_engine/**: 核心调度引擎。负责执行核心的决策逻辑，加载 .agent 模型进行推理计算。
+*   **alarm_engine/**: 报警引擎。持续监控系统状态数据，根据预设规则判断是否触发报警。
+*   **audit_log/**: 审计日志模块。负责记录系统中的关键操作和事件。
+*   **test_publisher.py**: 测试工具。用于模拟 chs-edge 节点发布测试数据。
+*   **tests/**: 单元测试与集成测试。
+*   **.env / .env.example**: 环境变量配置。

--- a/chs-twin-factory/README.md
+++ b/chs-twin-factory/README.md
@@ -1,6 +1,32 @@
-# CHS-Twin-Factory
+# chs-twin-factory - AI Agent 研发中心
 
-This directory is for the CHS-Twin-Factory product.
+*   **角色**: 智能体的“兵工厂”。这是一个服务化的 AI Agent 研发平台，负责消费 CHS-SDK 的能力，提供从环境封装、算法训练、实验管理到模型打包的完整 MLOps 工具链。
 
-- `backend/`: Contains the backend source code.
-- `frontend/`: Contains the frontend source code.
+## 详细目录结构与代码解析
+
+```
+chs-twin-factory/
+├── README.md
+└── backend/
+    ├── migrations/
+    │   ├── README
+    │   ├── env.py
+    │   ├── script.py.mako
+    │   └── versions/
+    ├── app.py
+    ├── debug_agent.py
+    ├── gym_wrapper.py
+    ├── requirements.txt
+    ├── rule_based_agent.py
+    └── test_app.py
+```
+
+### 代码现状分析
+
+*   **app.py**: Web 应用的核心入口。
+*   **gym_wrapper.py**: 关键的适配器，将 CHS-SDK 封装成标准的 Gymnasium 环境接口。
+*   **rule_based_agent.py**: 基准控制器。
+*   **debug_agent.py**: 调试工具。
+*   **migrations/**: 数据库版本管理 (Alembic)。
+*   **test_app.py**: 应用测试代码。
+*   **requirements.txt**: 依赖项列表。

--- a/water_system_sdk/README.md
+++ b/water_system_sdk/README.md
@@ -1,15 +1,100 @@
-# Water System Simulator SDK
+# CHS-SDK - 代码及功能说明
 
-This SDK provides a configurable and extensible platform for simulating various water systems, including reservoirs, channels, and control structures.
+## 产品说明：核心版与智能体版的关系
 
-## Installation
+CHS-SDK 的架构设计体现了清晰的层次关系，可以理解为包含一个 “核心版 (Core Version)” 和一个在其之上构建的 “智能体版 (Agent Version)”。
 
-Install the package using pip:
+### 核心版 (Core Version)
 
-```bash
-pip install .
+*   **核心目录**: `modules/`
+*   **定位**: 科学计算内核与数字孪生基础。`modules` 目录是整个 SDK 的技术基石，它提供了一套专业、完整的水文水动力学仿真模型。这一版本专注于精确地模拟物理世界，回答“如果……会发生什么？”的问题。
+
+### 智能体版 (Agent Version)
+
+*   **核心目录**: `agents/`, `factory/`, `workflows/`, `interfaces/` 等，它们围绕并消费 `modules/` 的能力。
+*   **定位**: 智能决策与自动化控制解决方案。智能体版在核心版提供的数字孪生环境之上，构建了一整套用于研发、训练、评估和部署“智能大脑”（Agent）的工具链。它专注于解决“接下来该怎么做？”的问题。
+
+## 完整目录结构与文件功能详解
+
+```
+chs_sdk/
+├── __init__.py
+├── agents/
+│   ├── __init__.py
+│   ├── base_agent.py
+│   ├── pid.py
+│   ├── mpc.py
+│   └── rl/
+│       ├── __init__.py
+│       ├── ppo_agent.py
+│       └── sac_agent.py
+├── components/
+│   ├── __init__.py
+│   ├── logger.py
+│   └── config_loader.py
+├── core/
+│   ├── __init__.py
+│   ├── simulator.py
+│   ├── state_manager.py
+│   └── event_bus.py
+├── factory/
+│   ├── __init__.py
+│   ├── trainer.py
+│   ├── evaluator.py
+│   └── model_registry.py
+├── interfaces/
+│   ├── __init__.py
+│   ├── env_interface.py
+│   └── module_interface.py
+├── modules/
+│   ├── __init__.py
+│   ├── hydrology/
+│   │   ├── xinanjiang.py
+│   │   └── swat.py
+│   ├── hydrodynamics/
+│   │   ├── saint_venant_solver.py
+│   │   └── network_builder.py
+│   ├── hydrodynamics_2d/
+│   │   ├── shallow_water_solver.py
+│   │   └── wet_dry_handler.py
+│   ├── hydro_distributed/
+│   │   └── grid_model.py
+│   ├── meshing/
+│   │   ├── tri_generator.py
+│   │   └── grid_generator.py
+│   ├── modeling/
+│   │   ├── coupler.py
+│   │   └── model_builder.py
+│   ├── identification/
+│   │   ├── objective_functions.py
+│   │   └── optimizers.py
+│   ├── data_processing/
+│   ├── basic_tools/
+│   ├── control/
+│   └── disturbances/
+├── preprocessing/
+│   ├── __init__.py
+│   ├── timeseries.py
+│   └── feature_engineering.py
+├── tools/
+│   ├── __init__.py
+│   └── epanet_adapter.py
+├── utils/
+│   ├── __init__.py
+│   └── helpers.py
+└── workflows/
+    ├── __init__.py
+    ├── training_workflow.py
+    └── simulation_workflow.py
 ```
 
-## Usage
-
-See the `examples` directory for detailed usage.
+*   **agents/**: 系统的大脑。定义了所有用于控制系统的决策逻辑。
+*   **components/**: 提供了可在项目中多处复用的、具有特定功能的高级组件。
+*   **core/**: SDK 的心脏，负责驱动整个仿真流程。
+*   **factory/**: 智能体的“兵工厂”，负责 Agent 的训练、评估和打包。
+*   **interfaces/**: 模块间的“法律合同”，定义了各模块交互的标准。
+*   **modules/**: 数字孪生的科学计算核心，一个专业级的科学计算引擎。
+*   **preprocessing/**: 数据的“清洗工”，负责处理输入到 SDK 的原始数据。
+*   **tools/**: 与行业标准软件进行交互的适配器。
+*   **utils/**: 提供了被广泛使用的通用、低级别的辅助函数。
+*   **workflows/**: 任务的“总导演”，将 SDK 的各种能力串联成端到端的任务流。


### PR DESCRIPTION
This commit generates detailed README.md files for the 6 core products in the CHS ecosystem:

- chs-sdk (in water_system_sdk/)
- chs-twin-factory
- chs-knowledge-hub
- chs-scada-dispatch
- chs-edge
- chs-hmi

The documentation is based on the provided source material and includes the product's role, a detailed directory structure, and an analysis of the code. This provides clear and accurate technical documentation for each product.